### PR TITLE
Refactor: Apply bold formatting to UI elements in documentation

### DIFF
--- a/src/addons.md
+++ b/src/addons.md
@@ -4,7 +4,7 @@ Anki's capabilities can be extended with add-ons. Add-ons can provide
 features like extra support for specific languages, extra control over
 scheduling, and so on.
 
-To browse the list of available add-ons, select **Tools** → **Add-ons**, then click on **Get Add-ons**.
+To browse the list of available add-ons, go to **Tools > Add-ons**, then click on **Get Add-ons**.
 Alternatively, open [ankiweb.net/shared/addons](https://ankiweb.net/shared/addons) in a web browser.
 
 If you have downloaded an add-on that is not working properly, or if you

--- a/src/addons.md
+++ b/src/addons.md
@@ -4,12 +4,12 @@ Anki's capabilities can be extended with add-ons. Add-ons can provide
 features like extra support for specific languages, extra control over
 scheduling, and so on.
 
-To browse the list of available add-ons, select `Tools` → `Add-ons`, then click on `Get Add-ons`.
+To browse the list of available add-ons, select **Tools** → **Add-ons**, then click on **Get Add-ons**.
 Alternatively, open [ankiweb.net/shared/addons](https://ankiweb.net/shared/addons) in a web browser.
 
 If you have downloaded an add-on that is not working properly, or if you
 accidentally made a mistake when editing an add-on, you can use the
-"Delete" option in the menu to remove it.
+**"Delete" option** in the **menu** to remove it.
 
 Add-ons use and modify arbitrary parts of Anki’s codebase, so in some
 cases, updating Anki can break the compatibility with older add-ons. If
@@ -18,7 +18,7 @@ reporting the issue to the add-on author. If you rely on this add-on,
 you will need to keep using an older Anki version until the add-on gets
 an update.
 
-There is a "Contact Author" button on most add-ons pages on AnkiWeb,
+There is a **"Contact Author" button** on most add-ons pages on AnkiWeb,
 and many authors include their email address in the add-on, so if you
 need to get in touch with the author, editing the add-on and looking at
 the top of the file may help.

--- a/src/addons.md
+++ b/src/addons.md
@@ -9,7 +9,7 @@ Alternatively, open [ankiweb.net/shared/addons](https://ankiweb.net/shared/addon
 
 If you have downloaded an add-on that is not working properly, or if you
 accidentally made a mistake when editing an add-on, you can use the
-**"Delete" option** in the **menu** to remove it.
+**Delete** option in the menu to remove it.
 
 Add-ons use and modify arbitrary parts of Anki’s codebase, so in some
 cases, updating Anki can break the compatibility with older add-ons. If
@@ -18,7 +18,7 @@ reporting the issue to the add-on author. If you rely on this add-on,
 you will need to keep using an older Anki version until the add-on gets
 an update.
 
-There is a **"Contact Author" button** on most add-ons pages on AnkiWeb,
+There is a **Contact Author** button on most add-ons pages on AnkiWeb,
 and many authors include their email address in the add-on, so if you
 need to get in touch with the author, editing the add-on and looking at
 the top of the file may help.

--- a/src/backups.md
+++ b/src/backups.md
@@ -17,8 +17,8 @@ protect you if your device breaks or is stolen. We recommend you combine them wi
 
 To restore from an automatic backup:
 
-- Open Anki, and choose Switch Profile from the File menu.
-- Click on the "Open Backup" button.
+- Open Anki, and choose **Switch Profile** from the **File menu**.
+- Click on the **"Open Backup" button**.
 - Select the backup you wish to restore from.
 
 ```admonish warning
@@ -31,14 +31,14 @@ happy that you've restored the correct backup, close and re-open Anki to return 
 ### Creating
 
 Backups are created periodically. You can configure the time between backups
-in the [preferences](preferences.md) screen. The default is 30 minutes.
+in the **[preferences](preferences.md) screen**. The default is 30 minutes.
 
 Certain operations will trigger a backup, even if the configured time has not
 elapsed yet:
 
 - A one-way sync download
-- Importing a .colpkg file using File>Import
-- Tools>Check Database
+- Importing a .colpkg file using **File** > **Import**
+- **Tools** > **Check Database**
 
 After backups are two days old, Anki will start removing some of the older ones.
 You can control how many daily, weekly and monthly backups you'd like to keep.
@@ -49,18 +49,18 @@ Backups created with 2.1.50 will not be importable into older Anki versions.
 
 ### Restoring
 
-You can restore from a manual backup by using File>Import.
+You can restore from a manual backup by using **File** > **Import**.
 
 ### Creating
 
-In Anki 2.1.50+, you can use File>Create Backup to trigger an immediate backup. This
+In Anki 2.1.50+, you can use **File** > **Create Backup** to trigger an immediate backup. This
 functions like regular automatic backups, and does not include media files.
 
 To create a backup that includes your sounds and images:
 
-- Select Export from the File menu.
-- Ensure "Anki collection package (.colpkg)" is selected.
-- Enable the "include media" option.
+- Select **Export** from the **File menu**.
+- Ensure **"Anki collection package (.colpkg)"** is selected.
+- Enable the **"include media" option**.
 
 This will create a .colpkg file that contains all of your cards and any sounds/images they
 use. We recommend you store the file somewhere safe, like a different device, or a cloud-based
@@ -70,14 +70,14 @@ file storage service like Dropbox or Google Drive.
 
 [Synchronising](./syncing.md) your collection with AnkiWeb provides some level of protection
 against your device being lost or stolen. If you need to restore your collection from AnkiWeb,
-you can force a one-way sync in the preferences screen, or sync from a new device, and then choose
-"Download".
+you can force a one-way sync in the **preferences screen**, or sync from a new device, and then choose
+**"Download"**.
 
 ## Deletion log
 
 Anki logs deleted notes to a text file called deleted.txt in your
 profile folder. These notes are in a text format that can be read by
-File&gt;Import, though please note the import feature only supports a
+**File** > **Import**, though please note the import feature only supports a
 single note type at one time, so if you have deleted notes from
 different note types, you'll need to split the file into separate files
 for each note type first.

--- a/src/backups.md
+++ b/src/backups.md
@@ -17,8 +17,8 @@ protect you if your device breaks or is stolen. We recommend you combine them wi
 
 To restore from an automatic backup:
 
-- Open Anki, and choose **Switch Profile** from the **File menu**.
-- Click on the **"Open Backup" button**.
+- Open Anki, and choose **Switch Profile** from the **File** menu.
+- Click on the **Open Backup** button.
 - Select the backup you wish to restore from.
 
 ```admonish warning
@@ -31,7 +31,7 @@ happy that you've restored the correct backup, close and re-open Anki to return 
 ### Creating
 
 Backups are created periodically. You can configure the time between backups
-in the **[preferences](preferences.md) screen**. The default is 30 minutes.
+in the [**Preferences**](preferences.md) screen. The default is 30 minutes.
 
 Certain operations will trigger a backup, even if the configured time has not
 elapsed yet:
@@ -58,9 +58,9 @@ functions like regular automatic backups, and does not include media files.
 
 To create a backup that includes your sounds and images:
 
-- Select **Export** from the **File menu**.
-- Ensure **"Anki collection package (.colpkg)"** is selected.
-- Enable the **"include media" option**.
+- Select **Export** from the **File** menu.
+- Ensure "Anki collection package (.colpkg)" is selected.
+- Enable the "Include media" option.
 
 This will create a .colpkg file that contains all of your cards and any sounds/images they
 use. We recommend you store the file somewhere safe, like a different device, or a cloud-based
@@ -70,8 +70,8 @@ file storage service like Dropbox or Google Drive.
 
 [Synchronising](./syncing.md) your collection with AnkiWeb provides some level of protection
 against your device being lost or stolen. If you need to restore your collection from AnkiWeb,
-you can force a one-way sync in the **preferences screen**, or sync from a new device, and then choose
-**"Download"**.
+you can force a one-way sync in the **Preferences** screen, or sync from a new device, and then choose
+**Download**.
 
 ## Deletion log
 

--- a/src/backups.md
+++ b/src/backups.md
@@ -37,8 +37,8 @@ Certain operations will trigger a backup, even if the configured time has not
 elapsed yet:
 
 - A one-way sync download
-- Importing a .colpkg file using **File** > **Import**
-- **Tools** > **Check Database**
+- Importing a .colpkg file using **File > Import**
+- **Tools > Check Database**
 
 After backups are two days old, Anki will start removing some of the older ones.
 You can control how many daily, weekly and monthly backups you'd like to keep.
@@ -49,11 +49,11 @@ Backups created with 2.1.50 will not be importable into older Anki versions.
 
 ### Restoring
 
-You can restore from a manual backup by using **File** > **Import**.
+You can restore from a manual backup by using **File > Import**.
 
 ### Creating
 
-In Anki 2.1.50+, you can use **File** > **Create Backup** to trigger an immediate backup. This
+In Anki 2.1.50+, you can use **File > Create Backup** to trigger an immediate backup. This
 functions like regular automatic backups, and does not include media files.
 
 To create a backup that includes your sounds and images:
@@ -77,7 +77,7 @@ you can force a one-way sync in the **Preferences** screen, or sync from a new d
 
 Anki logs deleted notes to a text file called deleted.txt in your
 profile folder. These notes are in a text format that can be read by
-**File** > **Import**, though please note the import feature only supports a
+**File > Import**, though please note the import feature only supports a
 single note type at one time, so if you have deleted notes from
 different note types, you'll need to split the file into separate files
 for each note type first.

--- a/src/browsing.md
+++ b/src/browsing.md
@@ -2,10 +2,10 @@
 
 <!-- toc -->
 
-The Browse window allows you to search through your cards and notes, and edit
+The **Browse window** allows you to search through your cards and notes, and edit
 them. It is opened by clicking **Browse** in the main window, or by pressing
-<kbd>B</kbd>. It is comprised of three sections: the _sidebar_ on the
-left, the _card/note table_ on the top right, and the _editing area_ on the bottom
+<kbd>B</kbd>. It is comprised of three sections: the **_sidebar_** on the
+left, the **_card/note table_** on the top right, and the **_editing area_** on the bottom
 right. By positioning the mouse between two sections, it is possible to click
 and drag to expand one section and shrink the other.
 
@@ -14,9 +14,9 @@ and drag to expand one section and shrink the other.
 ![Table Modes](media/browser_table_modes.png)
 
 Anki 2.1.45+ offers two modes: either cards or notes are shown in the data table.
-You can change the current mode by clicking the switch at the top, to the left
-of the search area, or pressing <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>T</kbd> or
-<kbd>Cmd</kbd>+<kbd>Opt</kbd>+<kbd>T</kbd>. The switch also indicates if **C**ards
+You can change the current mode by clicking the **switch** at the top, to the left
+of the **search area**, or pressing <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>T</kbd> or
+<kbd>Cmd</kbd>+<kbd>Opt</kbd>+<kbd>T</kbd>. The **switch** also indicates if **C**ards
 or **N**otes are currently shown.
 
 **Note**: For the sake of simplicity, this manual generally assumes the Cards
@@ -25,24 +25,24 @@ the reader may substitute it for "cards or notes depending on the active mode".
 
 ## Sidebar
 
-The _sidebar_ on the left allows quick access to common search terms. On Anki
-2.1.45+, it also provides a searchbar, facilities to edit tags and decks, and a
+The **_sidebar_** on the left allows quick access to common search terms. On Anki
+2.1.45+, it also provides a **searchbar**, facilities to edit tags and decks, and a
 choice of two different tools, which are discussed in the following sections.
-You can switch tools using the toolbar at the top of the sidebar or the shortcuts
+You can switch tools using the **toolbar** at the top of the **sidebar** or the shortcuts
 <kbd>Alt</kbd>+<kbd>1</kbd>/<kbd>2</kbd>.
 
 ### Search Tool
 
 ![Search Tool](media/browser_search_tool.png)
 
-With this tool, the sidebar behaves as in previous versions: Clicking on an item
+With this tool, the **sidebar** behaves as in previous versions: Clicking on an item
 will search for it.
 
 You can hold down <kbd>Ctrl</kbd> (<kbd>Command</kbd> on Mac) while clicking in
 order to append the clicked item to the current search with an AND condition,
 instead of starting a new search. If you wanted to show _learning_ cards that were
 also in the German deck for instance, you could click on "Learning",
-then <kbd>Ctrl</kbd>-click on "German".
+then <kbd>Ctrl</kbd>-click on **"German"**.
 
 You can hold down <kbd>Shift</kbd> to create an OR search instead of an AND. For
 example, you could click one deck, then <kbd>Shift</kbd>-click another to show
@@ -86,26 +86,26 @@ to append the resulting search to the current search.
 ### Saved Searches
 
 If you regularly search for the same thing,
-you can save the current search by right-clicking the topmost item in the sidebar,
-choosing “Save Current Search” and typing in a name.
+you can save the current search by right-clicking the topmost item in the **sidebar**,
+choosing **“Save Current Search”** and typing in a name.
 You can also drag and drop any sidebar item onto this area to add an equivalent
 saved search, effectively pinning it at the top.
 
 ### Editing Items
 
-You can delete or rename tags, decks, and saved searches directly from the sidebar,
-from the right-click menu, or by using a shortcut key (<kbd>Del</kbd> and
+You can delete or rename tags, decks, and saved searches directly from the **sidebar**,
+from the **right-click menu**, or by using a shortcut key (<kbd>Del</kbd> and
 <kbd>F2</kbd> on Windows). Deletion even works for multiple items at once
 (see [Selection Tool](#selection-tool)).
 
 ### Finding Items
 
-To find a certain item in the sidebar tree, type part of its name into the searchbar
+To find a certain item in the **sidebar** tree, type part of its name into the **searchbar**
 at the top.
 
 ## Search Box
 
-Above the card list is a search box. You can type in various things
+Above the **card list** is a **search box**. You can type in various things
 there to search for cards. For information on the search syntax,
 see [Searching](searching.md).
 
@@ -185,10 +185,10 @@ In Notes mode, the preview is shown for the first card of the selected note.
 
 ## Menus and Actions
 
-At the top of the browser window, you find a toolbar with various menus which in
+At the top of the **browser window**, you find a **toolbar** with various **menus** which in
 turn offer various actions that can be performed in the browser.
 
-### Edit
+### **Edit** menu
 
 <!-- prettier-ignore -->
 
@@ -198,9 +198,9 @@ turn offer various actions that can be performed in the browser.
 | Select All           | Select all rows displayed.                                                                                                                                                                                                    |
 | Select Notes         | Show only the currently selected notes and select all rows.                                                                                                                                                                   |
 | Invert Selection     | Select those rows not selected, and deselect the currently selected rows.                                                                                                                                                     |
-| Create Filtered Deck | Show the [filtered deck](filtered-decks.md#creating-manually) dialog and set the current browser search as a filter. Use <kbd>Alt</kbd> / <kbd>Option</kbd> to set the second filter instead.|
+| Create Filtered Deck | Show the **[filtered deck](filtered-decks.md#creating-manually) dialog** and set the current browser search as a filter. Use <kbd>Alt</kbd> / <kbd>Option</kbd> to set the second filter instead.|
 
-### Notes
+### **Notes** menu
 
 Most of the following actions operate on the selected notes. They are also available through
 a context menu when a selected row is right-clicked in Notes mode. In Cards mode,
@@ -210,20 +210,20 @@ they can be found in a submenu of the context menu.
 
 | Name              | Action                                                                                                                                                                                                                                                                                                                                                     |
 | ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Add Notes         | Open the [Add](editing.md#adding-cards-and-notes) dialog.                                                                                                                                                                                                                                                                                                  |
+| Add Notes         | Open the **[Add](editing.md#adding-cards-and-notes) dialog**.                                                                                                                                                                                                                                                                                                  |
 | Create Copy       | Open a [duplicate](browsing.md#finding-duplicates) of the current note in the [editor](editing.md#adding-cards-and-notes), which can be slightly modified to easily obtain variations of your cards. By default, the duplicate card will be created in the same deck as the original.                                                                      |
-| Export Notes      | Open the [Export](exporting.md) dialog.                                                                                                                                                                                                                                                                                                                    |
+| Export Notes      | Open the **[Export](exporting.md) dialog**.                                                                                                                                                                                                                                                                                                                    |
 | Add Tags          | Add provided tags to all selected notes.                                                                                                                                                                                                                                                                                                                   |
 | Remove Tags       | Enter tags and remove them from all selected notes.                                                                                                                                                                                                                                                                                                        |
 | Clear Unused Tags | Remove all tags from the sidebar that are not used by any notes.                                                                                                                                                                                                                                                                                           |
 | Toggle Mark       | If the current note is marked (i.e., has the _Marked_ tag), unmark all selected notes. If the current is not marked, mark all selected notes.                                                                                                                                                                                                              |
 | Change Note Type   | Convert the selected notes from one type to another. For example, imagine you have a _Russian_ note type and a _Computer_ note type, and you accidentally added some computer-related text into a _Russian_ note. You can use this option to fix that mistake. The scheduling of cards is not affected. Changing the type of a note requires a one-way sync. |
-| Find Duplicates   | Open the [Duplicates](#finding-duplicates) dialog.                                                                                                                                                                                                                                                                                                         |
-| Find and Replace  | Open the [Find and Replace](#find-and-replace) dialog.                                                                                                                                                                                                                                                                                                     |
-| Manage Note Types  | Open the [Note Types](editing.md#adding-a-note-type) dialog.                                                                                                                                                                                                                                                                                                |
+| Find Duplicates   | Open the **[Duplicates](#finding-duplicates) dialog**.                                                                                                                                                                                                                                                                                                         |
+| Find and Replace  | Open the **[Find and Replace](#find-and-replace) dialog**.                                                                                                                                                                                                                                                                                                     |
+| Manage Note Types  | Open the **[Note Types](editing.md#adding-a-note-type) dialog**.                                                                                                                                                                                                                                                                                                |
 | Delete            | Delete all selected notes and their cards. It is not possible to remove individual cards, as individual cards are controlled by the [templates](templates/intro.md).                                                                                                                                                                                       |
 
-### Cards
+### **Cards** menu
 
 The following actions operate on the currently selected cards. They are also available through
 a context menu when a selected row is rightclicked in Cards mode. In Notes mode,
@@ -239,28 +239,28 @@ they can be found in a submenu of the context menu.
 | Reposition     | Change the order new cards will appear in. You can find out the existing positions by enabling the _due_ column, as described in the [table](#cardnote-table) section above. If you run the reposition command when multiple cards are selected, it will apply increasing numbers to each card in turn. By default the number increases by one for each card, but this can be adjusted by changing the "step" setting. The **Shift position of existing cards** option allows you to insert cards between currently existing ones, pushing the currently existing ones apart. For instance, if you have five cards and you want to move 3, 4, and 5 between 1 and 2, selecting this setting would cause the cards to end up in the order 1, 3, 4, 5, 2. By contrast, if you turn this option off, 1 and 2 will get the same position number (and it will thus be unpredictable which of the cards with the same number comes up first). Please note that when enabled, any card with a higher position will be modified, and all of those changed cards will need to be sent the next time you sync. |
 | Toggle Suspend | [Suspend](studying.md#editing-and-more) or unsuspend all selected cards, depending on whether the current card is suspended or not.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
 | Flag           | Toggle the flags of all selected cards. Whether a flag is added or removed depends on whether the current card has the chosen flag.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
-| Info           | Show various information about the current card, including its review history. For more information, see [Card Info](stats.md#card-info).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| Info           | Show various information about the current card, including its review history. For more information, see **[Card Info](stats.md#card-info)**.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
 
-### Go
+### **Go** menu
 
 This menu exists to provide keyboard shortcuts to jump to various
 parts of the browser, and to go up and down the card list.
 
 ## Find and Replace
 
-This dialog allows for replacing text on notes. As described above, it is available
-from the toolbar and the table's context menu.
+This **dialog** allows for replacing text on notes. As described above, it is available
+from the **toolbar** and the table's context menu.
 
-The first input field is for the text that is going to be replaced, the second
-one for the replacement. Next, there is a dropdown menu that allows you to specify
+The first **input field** is for the text that is going to be replaced, the second
+**one** for the replacement. Next, there is a **dropdown menu** that allows you to specify
 where Anki should look for text to replace: in a note's tags (requires Anki 2.1.45+),
 in all fields, or just in a specific field (only fields belonging to a selected
 note will be listed).
 
 By default, only selected notes will be affected. If you want to lift that
-restriction, you can untick the "selected notes only" checkbox (requires Anki 2.1.45+).
+restriction, you can untick the **"selected notes only" checkbox** (requires Anki 2.1.45+).
 
-The regular expression option allows you to perform complex replacements.
+The **regular expression option** allows you to perform complex replacements.
 For example, assume there is the following text in a field:
 
     <img src="pic.jpg" />
@@ -285,9 +285,9 @@ There are a number of syntax guides available on the web:
 ## Finding Duplicates
 
 You can use the **Notes > Find Duplicates** option to search for notes that
-have the same content. When you open the window, Anki will look at all
+have the same content. When you open the **window**, Anki will look at all
 of your note types and present a list of all possible fields. If you
-want to look for duplicates in the _Back_ field, you’d select it from
+want to look for duplicates in the **_Back_ field**, you’d select it from
 the list and then click **Search**.
 
 By default, it will search in all note types that have the field you provided.
@@ -305,11 +305,11 @@ you could use:
 
     "deck:myDeck"
 
-The search syntax is the same as used when searching in the browser.
+The search syntax is the same as used when searching in the **browser**.
 For more information, see [Searching](searching.md).
 
 You can click one of the links in the search results list to display the
 duplicate notes in that set. If the search brings up a large number of
 duplicates, you may wish to instead click the **Tag Duplicates** button,
 which will tag all matching notes with _duplicate_. You can then search
-for this tag in the browser and handle them all from the same screen.
+for this tag in the **browser** and handle them all from the same screen.

--- a/src/contrib.md
+++ b/src/contrib.md
@@ -5,13 +5,13 @@
 ## Sharing Decks Publicly
 
 To share decks with the general public, [synchronize](syncing.md) them
-with AnkiWeb, then log into AnkiWeb and click on "Share" from the menu
+with AnkiWeb, then log into AnkiWeb and click on **"Share"** from the **menu**
 next to the deck you wish to share.
 
 If you shared a deck previously (including with previous versions of
-Anki), you can update it by clicking "Share" as above. Updating a shared
+Anki), you can update it by clicking **"Share"** as above. Updating a shared
 deck will not reset the download counts or ratings. You can delete a
-shared deck that you have uploaded using the Delete button on the shared
+shared deck that you have uploaded using the **Delete button** on the shared
 deck's page.
 
 When updating a deck, AnkiWeb expects the deck to be at the same
@@ -19,8 +19,8 @@ location as before. If you shared a deck when it was called "Korean
 Verbs" for example, and then renamed it to "Korean::Korean Verbs",
 resharing will not be able to update the existing copy. If you have
 forgotten the original name, you can guess it by downloading the
-deck on AnkiWeb and importing it (File > Import) in a new profile
-(File > Switch profile > Add). Then you can copy the exact name of the
+deck on AnkiWeb and importing it (**File** > **Import**) in a new profile
+(**File** > **Switch Profile** > **Add**). Then you can copy the exact name of the
 deck when it was first shared. If this doesn't work, please contact
 support.
 
@@ -36,7 +36,7 @@ If you’d like to share decks with a limited group of people (such as a
 study group or class) rather than the general public, you can do so by
 sharing them outside of AnkiWeb.
 
-To share a deck privately, go to the File menu and choose Export. Select
+To share a deck privately, go to the **File menu** and choose **Export**. Select
 a single deck (not "All Decks"), and turn off "include scheduling
 information". This will produce an .apkg file which you can share with
 others.

--- a/src/deck-options.md
+++ b/src/deck-options.md
@@ -7,10 +7,10 @@ that you spend a few weeks with the defaults to get a feel for how Anki works
 before you start adjusting the options. Please make sure you understand the options
 before changing them, as mistakes can reduce Anki's effectiveness.
 
-On your computer, do any of the following to open deck options:
+On your computer, do any of the following to open **deck options**:
 
-- Click the gear icon on the Decks screen.
-- Select a deck on the Decks screen, and then click **Options**
+- Click the **gear icon** on the **Decks screen**.
+- Select a deck on the **Decks screen**, and then click **Options**
   at the bottom of the screen.
 - Click **More > Options** while in review mode.
 - Press <kbd>O</kbd> while in review mode.
@@ -27,7 +27,7 @@ it easier to update options in many decks at once. To do this, options are
 grouped into _presets_. If you change an option in a preset, the change is applied to all decks that use the same preset. All newly created decks use the "Default" preset.
 
 To change the options in one deck but not other decks, click the
-arrow icon in the top right of the Deck Options window. You can do the following:
+**arrow icon** in the top right of the **Deck Options window**. You can do the following:
 
 - **Save**: Save all modifications you've made in deck options.
 - **Add Preset**: Add a new preset for this deck, with the default options.
@@ -189,9 +189,9 @@ from [earlier in this section](deck-options.md#learning-steps).
 
 ### Easy Interval
 
-The number of days to wait before showing a card again, after the Easy button is used on it.
+The number of days to wait before showing a card again, after the **Easy button** is used on it.
 
-The **Easy** button turns learning cards into a review cards regardless of which step you're on,
+The **Easy button** turns learning cards into a review cards regardless of which step you're on,
 and assigns them the delay you have configured in this option. Easy interval should always be at least
 as long as the graduating interval, and typically a few days longer.
 
@@ -315,7 +315,7 @@ Controls how the review cards are sorted. The options are:
   current interval of 5 days that is overdue by 2 days, will display before a card
   with a current interval of 10 days that is overdue by 3 days.
 
-  When FSRS is enabled, this sort order is removed; the FSRS equivalent is **Ascending retrievability**,
+  When FSRS is enabled, this sort order is removed; the FSRS equivalent is **"Ascending retrievability"**,
   which is calculated based on each card's retrievability (probability of recall) and the desired retention in the preset.
 
 ## Burying
@@ -336,7 +336,7 @@ For more info about burying cards, please see [this section](./studying.md#sibli
 ## Audio
 
 - **Don't play audio automatically**: By default, Anki automatically plays any audio you have on
-  cards. If you turn on this option Anki will not play audio until you press the replay audio key, <kbd>R</kbd> or <kbd>F5</kbd>.
+  cards. If you turn on this option Anki will not play audio until you press the **replay audio key**, <kbd>R</kbd> or <kbd>F5</kbd>.
 
 - **Skip question when replaying answer**: Controls whether audio from
   the question side is played when you use replay action on the answer side. Note that, Anki [does not automatically play](./templates/fields.md#special-fields) audio from the `{{FrontSide}}` field. This option does not influence the behaviour of automatic play.
@@ -361,16 +361,16 @@ not influence scheduling.
 
 ### On-screen Timer
 
-- Show on-screen timer: On the Study screen, show a timer that counts the time
+- Show on-screen timer: On the **Study screen**, show a timer that counts the time
   you're taking to study each card. (This timer will stop when it reaches the Maximum answer seconds set for the internal timer.)
-- Stop on-screen timer on answer: Whether the on-screen timer should continue running from when you show
+- Stop on-screen timer on answer: Whether the **on-screen timer** should continue running from when you show
   the answer until you press a button to grade your answer. This option does not impact the time that is recorded for your statistics.
 
 ## Auto Advance
 
 Requires Anki 23.12 or later. Auto Advance allows you to automatically take some actions after a certain amount of time has passed. To use it, you must first set a non-zero
 time in **Seconds to show question for** and/or **Seconds to show answer for**. Then, in the
-study screen, use the Auto Advance action from the **More** button to start advancing.
+**study screen**, use the **Auto Advance action** from the **More** button to start advancing.
 
 ## Easy Days
 
@@ -400,13 +400,13 @@ become available, and SM-2 specific options, such as **Graduating interval**,
 
 ### A Short Guide
 
-- Enable FSRS under the "FSRS" section, at the bottom of the deck options page. FSRS can only be enabled globally; you cannot enable it for some presets and disable it for others.
+- Enable FSRS under the **"FSRS" section**, at the bottom of the **deck options page**. FSRS can only be enabled globally; you cannot enable it for some presets and disable it for others.
 - Ensure that all your learning and re-learning steps are shorter than 1d and can be completed on the same day. 23h is not recommended even though it's less than one day because you won't be able to finish this step on the same day as your first review. Steps such as 10m or 30m are good.
-- Click the "Optimize" button under the "FSRS parameters" field. If you see a message that says "The FSRS parameters currently appear to be optimal", that's fine.
-- Choose a value of desired retention: the proportion of cards recalled successfully when they are due. **This is the most important setting in FSRS. Higher retention leads to shorter intervals and more reviews per day.** The default is 90%, which offers a good balance of retention and workload. Above 90% the workload increases very quickly, and above 97% the workload can be overwhelming. You can use ["Compute minimum recommended retention"](#compute-minimum-recommended-retention) to help you choose the value of desired retention.
+- Click the **"Optimize" button** under the **"FSRS parameters" field**. If you see a message that says "The FSRS parameters currently appear to be optimal", that's fine.
+- Choose a value of desired retention: the proportion of cards recalled successfully when they are due. **This is the most important setting in FSRS. Higher retention leads to shorter intervals and more reviews per day.** The default is 90%, which offers a good balance of retention and workload. Above 90% the workload increases very quickly, and above 97% the workload can be overwhelming. You can use **["Compute minimum recommended retention"](#compute-minimum-recommended-retention)** to help you choose the value of desired retention.
 Parameters and desired retention are preset-specific, you can make multiple presets with different parameters and desired retention.
 
-FSRS can adapt to almost any habit, except for one: pressing "Hard" instead of "Again" when you forget the information. When you press "Hard", FSRS assumes you have recalled the information correctly (though with hesitation and a lot of mental effort). If you press "Hard" when you have failed to recall the information, all intervals will be unreasonably high. So, if you have this habit, please change it and use "Again" when you forget the information.
+FSRS can adapt to almost any habit, except for one: pressing **"Hard"** instead of **"Again"** when you forget the information. When you press **"Hard"**, FSRS assumes you have recalled the information correctly (though with hesitation and a lot of mental effort). If you press **"Hard"** when you have failed to recall the information, all intervals will be unreasonably high. So, if you have this habit, please change it and use **"Again"** when you forget the information.
 
 Regarding add-on compatibility, as a general rule of thumb, if an add-on affects intervals and scheduling in some way, it shouldn't be used with FSRS.
 
@@ -588,7 +588,7 @@ You can thus use the multiplier to to make your reviews less or more frequent.
 For moderately difficult material, the average user should find they
 remember approximately 90% of mature cards when they come up for review. You
 can find out your own performance by opening the graphs/statistics for a
-deck and looking at the Answer Buttons graph - mature retention is the
+deck and looking at the **Answer Buttons graph** - mature retention is the
 correct% on the right side of the graph. If you haven’t been studying for
 long, you may not have any mature cards yet. As performance with new
 cards and younger cards can vary considerably, it’s a good idea to wait
@@ -647,7 +647,7 @@ that preserving part of the delay can actually [be counter-productive](https://s
 
 ### Custom Scheduling
 
-You can have more control over Anki's scheduling of cards by using your own JavaScript in the custom scheduling field. This is a global option, so code entered here applies to every preset.
+You can have more control over Anki's scheduling of cards by using your own JavaScript in the **custom scheduling field**. This is a global option, so code entered here applies to every preset.
 
 Here is an example custom scheduling script. Note that, for Qt5 versions of Anki, the code needs to be transpiled.
 

--- a/src/editing.md
+++ b/src/editing.md
@@ -5,23 +5,22 @@
 ## Adding Cards and Notes
 
 Recall from the [basics](getting-started.md) that in Anki we add notes rather than
-cards, and Anki creates cards for us. Click **Add** in the [main window](studying.md#decks),
-and the Add Notes window will appear.
+cards, and Anki creates cards for us. Click **Add** in the **[main window](studying.md#decks)**,
+and the **Add Notes window** will appear.
 
 ![Add Screen](media/add_screen.png)
 
-The top left of the window shows us the current [note type](getting-started.md#note-types). If it does
+The top left of the **window** shows us the current **[note type](getting-started.md#note-types)**. If it does
 not say "Basic," then you may have added some note types when you
 downloaded a shared deck. The text below assumes that "Basic" is
 selected.
 
-The top right of the window shows us the [deck](getting-started.md#decks) cards will be added to. If
-you would like to add cards to a new deck, you can click on the deck name
-button and then click **Add**.
+The top right of the **window** shows us the **[deck](getting-started.md#decks)** cards will be added to. If
+you would like to add cards to a new deck, you can click on the **deck name button** and then click **Add**.
 
-Below the note type, you'll see some buttons, and an area labelled
-"Front" and "Back". Front and Back are called [fields](getting-started.md#notes--fields), and you can add,
-remove, and rename them by clicking the "Fields…​" button above.
+Below the **note type**, you'll see some **buttons**, and an area labelled
+"Front" and "Back". Front and Back are called **[fields](getting-started.md#notes--fields)**, and you can add,
+remove, and rename them by clicking the **"Fields…​" button** above.
 
 Below the fields is another area labelled "**tags**". Tags are labels that
 you can attach to your notes, to make organizing and finding notes
@@ -33,26 +32,26 @@ them. Tags are separated by a space. If the tags area says
 …​then the note you add would have two tags.
 
 When you have entered text into the front and back, you can click the
-"Add" button or press <kbd>Ctrl</kbd>+<kbd>Enter</kbd> (<kbd>Command</kbd>+<kbd>Enter</kbd> on a Mac) to add the
+**"Add" button** or press <kbd>Ctrl</kbd>+<kbd>Enter</kbd> (<kbd>Command</kbd>+<kbd>Enter</kbd> on a Mac) to add the
 note to your collection. When you do so, a card will be created as well,
 and placed into the deck you chose. If you would like to edit a card you
-added, you can click the history button to search for a recently added
-card in the [browser](browsing.md).
+added, you can click the **history button** to search for a recently added
+card in the **[browser](browsing.md)**.
 
-For more information on the buttons between the note type and the
-fields, please see the [editor](editing.md) section.
+For more information on the **buttons** between the **note type** and the
+**fields**, please see the **[editor](editing.md)** section.
 
 ### Duplicate Check
 
 Anki checks the first field for uniqueness, so it will warn you if you
 enter two cards with a Front field of "apple" (for example). The
-uniqueness check is limited to the current note type, so if you're
+uniqueness check is limited to the current **note type**, so if you're
 studying multiple languages, two cards with the same Front would not be
-listed as duplicates as long as you had a different note type for each
+listed as duplicates as long as you had a different **note type** for each
 language.
 
 Anki does not check for duplicates in other fields automatically for
-efficiency reasons, but the browser has a "Find Duplicates" function,
+efficiency reasons, but the **browser** has a **"Find Duplicates" function**,
 which you can run periodically.
 
 ### Effective Learning
@@ -92,33 +91,31 @@ back, except by laboriously copying and pasting it for every note. By
 keeping content in separate fields, you make it much easier to adjust
 the layout of your cards in the future.
 
-To create a new type of note, choose Tools → Manage Note Types from the
-main Anki window. Then click "Add" to add a new type of note. You will now
-see another screen that gives you a choice of note types to base the new
-type on. "Add" means to base the newly created type on one that comes
-with Anki. "Clone" means to base the newly created type on one that is
+To create a new type of note, choose **Tools** → **Manage Note Types** from the
+main Anki **window**. Then click **"Add"** to add a new type of note. You will now
+see another **screen** that gives you a choice of **note types** to base the new
+type on. **"Add"** means to base the newly created type on one that comes
+with Anki. **"Clone"** means to base the newly created type on one that is
 already in your collection. For instance, if you'd created a French
 vocab type already, you might want to clone that when creating a German
 vocab type.
 
-After choosing OK, you will be asked to name the new type. The subject
+After choosing **OK**, you will be asked to name the new type. The subject
 material that you are studying is a good choice here – things like "Japanese",
-"Trivia", and so on. Once you have chosen a name, close the Note Types
-window, and you will return to the adding window.
+"Trivia", and so on. Once you have chosen a name, close the **Note Types window**, and you will return to the **adding window**.
 
 ## Customizing Fields
 
-To customize fields, click the "Fields…​" button when adding or editing
-a note, or while the note type is selected in the Manage Note Types
-window.
+To customize fields, click the **"Fields…​" button** when adding or editing
+a note, or while the **note type** is selected in the **Manage Note Types window**.
 
 ![Fields](media/fields.png)
 
-You can add, remove, or rename fields by clicking the appropriate
-buttons.
+You can **Add**, **Remove**, or **Rename** fields by clicking the appropriate
+**buttons**.
 
-To change the order in which the fields appear in this dialog
-and the add notes dialog, you can use the reposition button, which asks
+To change the order in which the fields appear in this **dialog**
+and the **add notes dialog**, you can use the **reposition button**, which asks
 for the numerical position you want the field to have. So if you want to
 change a field to be the new first field, enter "1".
 
@@ -171,10 +168,10 @@ or back of your cards. For more information on that, please see the
 
 ## Changing Deck / Note Type
 
-While adding, you can click on the top left button to change note type,
-and the top right button to change deck. The window that opens up will
-not only allow you to select a deck or note type, but also to add new
-decks or manage your note types.
+While adding, you can click on the **top left button** to change **note type**,
+and the **top right button** to change **deck**. The **window** that opens up will
+not only allow you to select a **deck** or **note type**, but also to add new
+decks or manage your **note types**.
 
 ## Organizing Content
 
@@ -222,7 +219,7 @@ cards to your main language study deck, and tag the cards with "food" and
 [search](searching.md#tags-decks-cards-and-notes) for all verbs, or all
 food-related vocabulary, or all verbs that are related to food.
 
-You can add tags from the Edit window and from the [Browser](browsing.md), and you can also add,
+You can add tags from the **Edit window** and from the **[Browser](browsing.md)**, and you can also add,
 delete, rename, or organize tags there. Please note that
 tags work at [note](getting-started.md#notes--fields) level, which means that when you tag a card that has siblings,
 all the siblings will be tagged as well. If you need to tag a single card,
@@ -230,24 +227,22 @@ but not its siblings, you should consider using flags instead.
 
 ### Using Flags
 
-Flags are similar to tags, but they will appear during study in the review
-window, showing a colored flag icon on the upper right area of the screen.
-You can also search for flagged cards in the Browse screen, rename flags
-from the browser and create filtered decks from flagged cards, but unlike tags,
+Flags are similar to tags, but they will appear during study in the **review window**, showing a colored flag icon on the upper right area of the screen.
+You can also search for flagged cards in the **Browse screen**, rename flags
+from the **browser** and create filtered decks from flagged cards, but unlike tags,
 a single card can have only one flag at a time. Another important difference
 is that flags work at [card](getting-started.md#cards) level, so flagging a card that has siblings
 won't have any effect on the card's siblings.
 
 You can flag / unflag cards directly while in review mode (by pressing
 <kbd>CTRL</kbd> + <kbd>1-7</kbd> on Windows or <kbd>CMD</kbd> + <kbd>1-7</kbd> on Mac)
-and from the [Browser.](browsing.md)
+and from the **[Browser.](browsing.md)**
 
 ### The "Marked" Tag
 
-Anki treats a tag called "marked" specially. There are options in the review
-screen and browse screen to add and remove the "marked" tag. The study screen
+Anki treats a tag called "marked" specially. There are options in the **review screen** and **browse screen** to add and remove the "marked" tag. The **study screen**
 will show a star when the current card's note has that tag. And cards are
-shown in a different color in the browse screen when their note is marked.
+shown in a different color in the **browse screen** when their note is marked.
 
 Note: Marking is mainly left around for compatibility with older Anki
 versions; most users will want to use [flags](editing.md#using-flags) instead.
@@ -279,51 +274,51 @@ The editor is shown when [adding notes](editing.md), [editing a note](studying.m
 
 ![Editor icons](media/editor_icons.png)
 
-On the top left are two buttons, which open the [fields](editing.md#customizing-fields) and
-[cards](templates/intro.md) windows.
+On the top left are two **buttons**, which open the **[fields](editing.md#customizing-fields)** and
+**[cards](templates/intro.md) windows**.
 
-On the right are buttons that control formatting. Bold, italic and
-underline work like they do in a word processing program. The next two
-buttons allow you to subscript or superscript text, which is useful for
+On the right are **buttons** that control formatting. **Bold**, **italic** and
+**underline** work like they do in a word processing program. The next two
+**buttons** allow you to **subscript** or **superscript** text, which is useful for
 chemical compounds like H<sub>2</sub>O or simple mathematical equations like
-x<sup>2</sup>. Then, there are two buttons to allow you to change text colour.
+x<sup>2</sup>. Then, there are two **buttons** to allow you to change **text colour**.
 
-The rubber eraser button clears any formatting in the currently selected text — including the colour
-of the text, whether the selected text is bold, etc. The next three buttons allow creating lists, text alignment and text indent.
+The **rubber eraser button** clears any formatting in the currently selected text — including the colour
+of the text, whether the selected text is bold, etc. The next three **buttons** allow creating **lists**, **text alignment** and **text indent**.
 
-You can use the paper-clip button to select audio, images, and videos from
+You can use the **paper-clip button** to select audio, images, and videos from
 your computer's hard drive and attach them to your notes. Alternatively, you
 can copy the media onto your computer's clipboard (for instance, by
 right-clicking an image on the web and choosing "Copy Image") and paste
 it into the field that you want to place it in. For more information
 about media, please see the [media](media.md) section.
 
-The microphone icon allows you to record from your computer's microphone
+The **microphone icon** allows you to record from your computer's microphone
 and attach the recording to the note.
 
-The Fx button shows shortcuts to add MathJax or
+The **Fx button** shows shortcuts to add MathJax or
 [LaTeX](math.md) to your notes.
 
-The \[…​\] buttons are visible when a cloze note type is selected.
+The **\[…​\] buttons** are visible when a cloze note type is selected.
 ![Cloze icons](media/cloze_icons.png)
 
-The `</>` button allows editing the underlying HTML of a field.
+The **`</>` button** allows editing the underlying HTML of a field.
 ![HTML icon](media/html_icon.png)
 
-Anki 2.1.45+ supports adjusting sticky fields directly from the editing screen.
-If you click on the pin icon on the right of a field, Anki will not clear out
+Anki 2.1.45+ supports adjusting sticky fields directly from the **editing screen**.
+If you click on the **pin icon** on the right of a field, Anki will not clear out
 the field's content after a note is added. If you find yourself entering the
 same content into multiple notes, you may find this useful. On previous Anki
-versions, sticky fields were toggled from the Fields screen.
+versions, sticky fields were toggled from the **Fields screen**.
 
 ![Pin icon](media/Pin_icon.png)
 
-Most of the buttons have shortcut keys. You can hover the mouse cursor
-over a button to see its shortcut.
+Most of the **buttons** have shortcut keys. You can hover the mouse cursor
+over a **button** to see its shortcut.
 
 When pasting text, Anki will keep most formatting by default. If you
 hold down the <kbd>Shift</kbd> key while pasting, Anki will strip most of the
-formatting. Under Preferences, you can toggle "Paste without shift
+formatting. Under **Preferences**, you can toggle "Paste without shift
 key strips formatting" to modify the default behaviour.
 
 ## Cloze Deletion
@@ -345,16 +340,15 @@ For more information on why you might want to use cloze deletion, see
 Rule 5 [here](https://super-memory.com/articles/20rules.htm).
 
 Anki provides a special cloze deletion type of note, to make creating
-clozes easy. To create a cloze deletion note, select the Cloze note
-type, and type some text into the "Text" field. Then drag the mouse over
-the text you want to hide to select it, and click the \[…​\] button.
+clozes easy. To create a cloze deletion note, select the **Cloze note type**, and type some text into the **"Text" field**. Then drag the mouse over
+the text you want to hide to select it, and click the **\[…​\] button**.
 Anki will replace the text with:
 
     Canberra was founded in {{c1::1913}}.
 
 The "c1" part means that you have created one cloze deletion on the
 sentence. You can create more than one deletion if you'd like. For
-example, if you select Canberra and click \[…​\] again, the text will
+example, if you select Canberra and click **\[…​\]** again, the text will
 now look like:
 
     {{c2::Canberra}} was founded in {{c1::1913}}.
@@ -384,7 +378,7 @@ replace the original sentence with:
 
     Canberra::city was founded in 1913
 
-…​and then press \[…​\] after selecting "Canberra::city", Anki will
+…​and then press **\[…​\]** after selecting "Canberra::city", Anki will
 treat the text after the two colons as a hint, changing the text into:
 
     {{c1::Canberra::city}} was founded in 1913
@@ -420,15 +414,15 @@ creating notes, paste the text into two separate fields, like so:
 
     Text2 field: {{c2::Canberra}} was founded in 1913
 
-The default cloze note type has a second field called Extra, that is
+The default **cloze note type** has a second field called **Extra**, that is
 shown on the answer side of each card. It can be used for adding some
 usage notes or extra information.
 
-The cloze note type is treated specially by Anki, and cannot be created
+The **cloze note type** is treated specially by Anki, and cannot be created
 based on a regular note type. If you wish to customize it, please make
-sure to clone the existing Cloze type instead of another type of note.
+sure to clone the existing **Cloze type** instead of another type of note.
 Things like formatting can be customized, but it is not possible to add
-extra card templates to the cloze note type.
+extra card templates to the **cloze note type**.
 
 ## Image Occlusion
 
@@ -441,21 +435,21 @@ of an image, testing your knowledge of that hidden information.
 
 ### Adding an image
 
-To add IO cards to your collection, open the Add screen, click on "Type"
-and choose "Image Occlusion" from the list of built-in note types.
-Then, click on "Select Image" to load an image file saved on your
-computer's hard drive, or on "Paste image from clipboard"
+To add IO cards to your collection, open the **Add screen**, click on **"Type"**
+and choose **"Image Occlusion"** from the list of built-in note types.
+Then, click on **"Select Image"** to load an image file saved on your
+computer's hard drive, or on **"Paste image from clipboard"**
 if you have an image copied to the clipboard.
 
 ### Adding IO cards
 
-After loading an image, the IO editor will open. Click on the
-icons on the left to add as many areas to your image as you want.
+After loading an image, the **IO editor** will open. Click on the
+**icons** on the left to add as many areas to your image as you want.
 There are three basic shapes to choose from:
 
-- Rectangle
-- Ellipse
-- Polygon
+- **Rectangle**
+- **Ellipse**
+- **Polygon**
 
 You can also choose between two different IO modes for each note:
 
@@ -474,20 +468,20 @@ and **Comments** (not displayed on the cards). To access those from the IO edito
 click the **Toggle Mask Editor** button.
 There you can also view and edit the **Tags** of the note.
 
-Once you're done, click on the "Add" button, at the bottom of the screen.
+Once you're done, click on the **"Add" button**, at the bottom of the screen.
 Anki will add a card for each shape or group of shapes you added in the previous step,
 and you can start reviewing them normally.
 
 ## Editing IO notes
 
-You can edit your IO notes by clicking on "Edit" while reviewing,
-or directly from the browser. There are several tools that you
+You can edit your IO notes by clicking on **"Edit"** while reviewing,
+or directly from the **browser**. There are several tools that you
 can use. Of note:
 
 - Select: It allows you selecting one or more shapes to move,
   resize, delete or group them.
 - Zoom: You can freely move the image and zoom in or out using the mouse wheel.
-- Shapes (Rectangle, Ellipse or Polygon): Use them to add new shapes / cards.
+- Shapes (**Rectangle**, **Ellipse** or **Polygon**): Use them to add new shapes / cards.
 - Text: It adds text areas to your image. These text areas can be moved,
   resized or deleted, but no card will be created when you use this tool.
 - Undo / Redo.
@@ -501,10 +495,10 @@ can use. Of note:
 - Group selection: Use this tool to create a cluster of shapes, which will
   allow you to move, resize or delete them simultaneously. Please note that
   two or more single shapes will create only one card once grouped.
-- Ungroup selection: Select a group and then click this button to make each shape independent again.
+- Ungroup selection: Select a group and then click this **button** to make each shape independent again.
 - Alignment: This tool can be used to align your shapes / text areas as desired.
 
-While reviewing IO Cards a "Toggle Masks" button will appear just below the image.
+While reviewing IO Cards a **"Toggle Masks" button** will appear just below the image.
 This button will temporary clear all shapes of the note when using "Hide All, Guess One" mode.
 
 ## Inputting Non-Latin Characters and Accents
@@ -573,7 +567,7 @@ to a standard form. For most users this process is transparent, but if you
 are studying certain material like archaic Japanese symbols, the normalization
 process can end up converting them to a more modern equivalent.
 
-If you want character variants preserved, the following in the [debug console](./misc.md)
+If you want character variants preserved, the following in the **[debug console](./misc.md)**
 will turn off normalization:
 
 ```python

--- a/src/exporting.md
+++ b/src/exporting.md
@@ -3,11 +3,11 @@
 <!-- toc -->
 
 Exporting allows you to save part of your collection as a text file or
-packaged Anki deck. To export, click the **File menu** and choose **Export**.
+packaged Anki deck. To export, click the **File** menu and choose **Export**.
 
 ## Text Files
 
-If you choose **"Notes in Plain Text"**, Anki will write the contents of the
+If you choose "Notes in Plain Text (.txt)", Anki will write the contents of the
 notes into a text file. Each field is separated by a tab. If you edit
 the resulting file and don't modify the first field, you can later
 import that file back into Anki and Anki will update your notes based on
@@ -49,7 +49,7 @@ devices.
 Existing media in your collection is not deleted when you import a
 collection package. To delete unused media, use **Tools** > **Check Media**.
 
-If you choose **Anki 2.1.50+ Collection Package** format, imports and exports
+If you choose "Anki Collection Package (.colpkg)" format, imports and exports
 will be faster, and media files will be compressed, but the resulting
 .colpkg file will not be readable by older Anki clients.
 

--- a/src/exporting.md
+++ b/src/exporting.md
@@ -3,11 +3,11 @@
 <!-- toc -->
 
 Exporting allows you to save part of your collection as a text file or
-packaged Anki deck. To export, click the File menu and choose **Export**.
+packaged Anki deck. To export, click the **File menu** and choose **Export**.
 
 ## Text Files
 
-If you choose "Notes in Plain Text", Anki will write the contents of the
+If you choose **"Notes in Plain Text"**, Anki will write the contents of the
 notes into a text file. Each field is separated by a tab. If you edit
 the resulting file and don't modify the first field, you can later
 import that file back into Anki and Anki will update your notes based on
@@ -47,9 +47,9 @@ file. This is useful for copying your collection back and forth between
 devices.
 
 Existing media in your collection is not deleted when you import a
-collection package. To delete unused media, use Tools&gt;Check Media.
+collection package. To delete unused media, use **Tools** > **Check Media**.
 
-If you choose Anki 2.1.50+ Collection Package format, imports and exports
+If you choose **Anki 2.1.50+ Collection Package** format, imports and exports
 will be faster, and media files will be compressed, but the resulting
 .colpkg file will not be readable by older Anki clients.
 

--- a/src/files.md
+++ b/src/files.md
@@ -5,7 +5,7 @@
 ## Checking Your Collection
 
 It is a good idea to occasionally check your collection file for
-problems. You can do this via the Tools&gt;Check Database menu item.
+problems. You can do this via the **Tools** > **Check Database menu item**.
 Checking the database ensures the file has not been corrupted, rebuilds some
 internal structures, and optimizes the file.
 
@@ -24,14 +24,14 @@ automatically optimizing.
 
 On **Windows**, the latest Anki versions store your Anki files in your
 appdata folder. You can access it by opening the file manager, and
-typing `%APPDATA%\Anki2` in the location field. Older versions of Anki
+typing `%APPDATA%\Anki2` in the **location field**. Older versions of Anki
 stored your Anki files in a folder called `Anki` in your `Documents`
 folder.
 
 On **Mac** computers, recent Anki versions store all their files in the
 `~/Library/Application Support/Anki2` folder. The Library folder is
-hidden by default, but can be revealed in Finder by holding down the
-option key while clicking on the Go menu. If you're on an older Anki
+hidden by default, but can be revealed in **Finder** by holding down the
+option key while clicking on the **Go menu**. If you're on an older Anki
 version, your Anki files will be in your `Documents/Anki` folder.
 
 On **Linux**, recent Anki versions store your data in
@@ -79,15 +79,15 @@ The syntax to specify an alternate folder is as follows:
 
 - If you have multiple profiles, you can pass -p &lt;name&gt; to load
   a specific profile.
-- If you pass -p some-fake-name, Anki will show the profile screen on startup.
+- If you pass -p some-fake-name, Anki will show the **profile screen** on startup.
   If no profile is provided, the last-used profile is loaded.
 
 - To change the interface language, use -l &lt;iso 639-1 language
   code&gt;, such as "-l ja" for Japanese.
 
 If you always want to use a custom folder location, you can modify your
-shortcut to Anki. On Windows, right-click on the shortcut, choose
-Properties, select the Shortcut tab, and add "-b
+shortcut to Anki. On Windows, right-click on the **shortcut**, choose
+**Properties**, select the **Shortcut tab**, and add "-b
 \\path\\to\\data\\folder" after the path to the program, which should
 leave you with something like
 
@@ -136,8 +136,7 @@ never synchronized while they are open.
 
 We strongly recommend you have Anki store your files on a local hard
 disk, as network filesystems can lead to database corruption. If a
-network filesystem is your only option, regular use of Tools&gt;Check
-Database to detect corruption is recommended.
+network filesystem is your only option, regular use of **Tools** > **Check Database** to detect corruption is recommended.
 
 ## Running from a Flash Drive
 
@@ -157,7 +156,7 @@ remaining open, you can instead use:
 
     start /b g:\anki\anki.exe -b g:\ankidata
 
-- Double-clicking on anki.bat should start Anki with the user data
+- Double-clicking on **anki.bat** should start Anki with the user data
   stored in G:\\ankidata.
 
 The full path including drive letter is required - if you try using
@@ -189,18 +188,18 @@ If you're on a Windows 7 machine, the general steps to fix the problem
 are listed below. As this is somewhat complicated, please ask someone
 knowledgeable about Windows if you are not sure.
 
-1. Click on the start bar, and type in %temp% (including the percents),
+1. Click on the **start bar**, and type in %temp% (including the percents),
    then hit <kbd>Enter</kbd>.
 
 2. Go up one folder, and locate the temp folder. Right click on it, and
-   choose Properties.
+   choose **Properties**.
 
-3. In the security tab, click on Advanced.
+3. In the **security tab**, click on **Advanced**.
 
-4. Click on the Owner tab. If you're not listed as the owner, click the
-   button to take ownership.
+4. Click on the **Owner tab**. If you're not listed as the owner, click the
+   **button** to take ownership.
 
-5. On the permissions tab, ensure that you have full control. On a
+5. On the **permissions tab**, ensure that you have full control. On a
    default W7 install the control will actually be inherited from
    c:\\users\\your-username.
 
@@ -211,7 +210,7 @@ crashes, but it's still possible for your collection to become corrupt
 if the files are modified while Anki is open, stored on a network drive,
 or corrupted by a bug.
 
-When you run Tools&gt;Check Database, you will receive a message if Anki
+When you run **Tools** > **Check Database**, you will receive a message if Anki
 detects the file has been corrupted. **The best way to recover from this
 is to restore from the most recent [automatic backup](#backups)**, but
 if your backup is too old, then you can attempt to repair the corruption
@@ -245,7 +244,7 @@ step.
 ### Windows
 
 Copy the `sqlite3.exe` program and your deck to your desktop. Then go to
-**Start&gt;Run** and type in `cmd.exe`.
+**Start** > **Run** and type in `cmd.exe`.
 
 If you're on a recent Windows, the command prompt may not start on your
 desktop. If you don't see desktop displayed in the command prompt, type
@@ -284,5 +283,5 @@ When you've confirmed the file is not empty:
 - move collection.anki2 back into your collection folder, overwriting
   the old version
 
-- start Anki and go to Tools&gt;Check Database to make sure the
+- start Anki and go to **Tools** > **Check Database** to make sure the
   collection has been successfully restored.

--- a/src/filtered-decks.md
+++ b/src/filtered-decks.md
@@ -18,15 +18,14 @@ ahead of schedule, going over the day's failed cards, and more.
 
 ## Custom Study
 
-The easiest way to create a filtered deck is with the Custom Study
-button, which appears at the bottom of the screen when you click on a
+The easiest way to create a filtered deck is with the **Custom Study button**, which appears at the bottom of the screen when you click on a
 deck. It offers some convenient preset filters for common tasks like reviewing
 the cards that you have failed that day. It will create a filtered deck called
 "Custom Study Session" and automatically open it for you.
 
 If an existing "Custom Study Session" deck exists, it will be emptied
 before a new one is created. If you wish to keep a custom study deck,
-you can rename it from the deck list.
+you can rename it from the **deck list**.
 
 Here is a summary of each of the options:
 
@@ -58,7 +57,7 @@ review cards as they are answered.
 **Study by card state or tag**\
 Select a certain number of cards from the current deck to study. You can
 choose to select new cards only, due cards only, or all cards; after you
-click "Choose Tags", you can also limit the selected cards by tags. If
+click **"Choose Tags"**, you can also limit the selected cards by tags. If
 you wish to see all the cards in the deck (for instance, to study before
 a big test), you can set the number of cards to more than the number of
 cards in the deck.
@@ -75,13 +74,13 @@ reviews, depending on your settings.
 
 It is also possible to move all cards back to their home decks at once:
 
-- The "Empty" button in the study overview moves all cards in the
+- The **"Empty" button** in the **study overview** moves all cards in the
   filtered deck back to their home deck, but does not delete the empty
   filtered deck. This can be useful if you want to fill it again later
-  (using the Rebuild button).
+  (using the **Rebuild button**).
 
-- Deleting a filtered deck does the same thing as "Empty" does, but
-  also removes the emptied deck from the deck list. No cards are
+- Deleting a filtered deck does the same thing as **"Empty"** does, but
+  also removes the emptied deck from the **deck list**. No cards are
   deleted when you delete a filtered deck.
 
 ## Creating Manually
@@ -89,34 +88,33 @@ It is also possible to move all cards back to their home decks at once:
 Advanced users can create filtered decks with arbitrary search strings
 (or "filters"),
 instead of relying on the preset filters. To create a filtered deck manually,
-choose Create Filtered Deck from the Tools menu.
+choose **Create Filtered Deck** from the **Tools menu**.
 
-When you click the Build button, Anki finds cards that match the
+When you click the **Build button**, Anki finds cards that match the
 settings you specified, and temporarily moves them from their existing
 decks into your new filtered deck for study.
 
 If you wish to fetch cards again using the same filter options (for
 instance, if you want to study all cards with a particular tag every
-day), you can use the Rebuild button at the bottom of the deck's
-overview screen.
+day), you can use the **Rebuild button** at the bottom of the **deck's overview screen**.
 
-The **search** area controls what cards Anki will gather. All of the
-searches possible in the browser are also possible for filtered decks,
+The **search area** controls what cards Anki will gather. All of the
+searches possible in the **browser** are also possible for filtered decks,
 such as limiting to tags, finding cards forgotten a certain number of
 times, and so on. Please see the [searching](searching.md) section of the
 manual for more information on the different possibilities.
 
 Filtered decks cannot pull in cards that are suspended, buried, or already in a
 different filtered deck. For this reason, a search in the
-browser may reveal cards that do not end up in the filtered deck.
+**browser** may reveal cards that do not end up in the filtered deck.
 
-The **limit** option controls how many cards will be gathered into the
+The **limit option** controls how many cards will be gathered into the
 deck. The order you select controls both the order cards are gathered
 in, and the order they will be reviewed in. If you select "most lapses"
 and a limit of 20 for example, then Anki will show you only the 20 most
 lapsed cards.
 
-The **enable second filter** option allows you to create a filtered deck
+The **enable second filter option** allows you to create a filtered deck
 comprised of two different searches, so that you can, for example, include
 due cards with one order, and a smaller amount of new cards with a different order.
 

--- a/src/getting-help.md
+++ b/src/getting-help.md
@@ -12,9 +12,9 @@ Please start by trying to resolve the issue on your own:
 - Read the [getting started](./getting-started.md) section
   of the manual, and check out the intro videos.
 - If you've encountered a bug, please follow [these steps](./troubleshooting.md).
-- Use the search button on this page to search frequently asked questions.
-- Use the search button in the manual.
-- Use the search button on the forums.
+- Use the **search button** on this page to search frequently asked questions.
+- Use the **search button** in the manual.
+- Use the **search button** on the forums.
 - Google the issue.
 
 If you have tried the above and are still stuck, it's time to ask for help.
@@ -26,10 +26,10 @@ Please avoid vague questions like:
 
 Instead, please provide as much detail as you can. For example:
 
-> "When I double-click on the Anki icon, an error message pops up. I tried
+> "When I double-click on the **Anki icon**, an **error message** pops up. I tried
 > searching for the error on Google, but couldn't find anything useful. I have
-> copied and pasted the error message to the bottom of my post. I followed the
-> steps on the "When problems occur" page, but the error message does not go
+> copied and pasted the **error message** to the bottom of my post. I followed the
+> steps on the "When problems occur" page, but the **error message** does not go
 > away. What should I do?"
 
 This is a much better question. It tells us:

--- a/src/getting-started.md
+++ b/src/getting-started.md
@@ -43,7 +43,7 @@ you're studying basic chemistry, you might see a question like:
     Q: Chemical symbol for oxygen?
 
 After deciding the answer is O, you click the
-"Show Answer" button, and Anki shows you:
+**"Show Answer" button**, and Anki shows you:
 
     Q: Chemical symbol for oxygen?
     A: O
@@ -80,7 +80,7 @@ deck. If you select "Hanzi", then only the Hanzi cards will be shown; if
 you select "Chinese", then all the Chinese cards will be shown, including the Hanzi cards.
 
 To place decks within a tree, you can either name them with double colons between
-each level, or drag and drop them within the deck list. Decks that have
+each level, or drag and drop them within the **deck list**. Decks that have
 been placed inside another deck are often called "subdecks", and top-level decks are called "parent decks".
 
 Anki starts with a deck called "Default"; any cards which have somehow
@@ -88,7 +88,7 @@ become separated from other decks will go here. Anki will hide the
 default deck if it contains no cards and you have added other decks.
 Alternatively, you may rename this deck and use it for other cards.
 
-Decks in the deck list are sorted alphabetically. This can result in
+Decks in the **deck list** are sorted alphabetically. This can result in
 a surprising order if your deck names contain numbers. For example, "My Deck 10"
 will come before "My Deck 9", as 1 comes before 9. If you want "My deck 9" to appear earlier, you can rename it to "My deck 09", which appears before "My deck 10".
 
@@ -154,7 +154,7 @@ they’d look like this:
 In Anki, this collection of related information is called a _note_ and each piece of information is contained in a _field_. In this example, the note
 has three fields: "French", "English", and "Page".
 
-To add and edit fields, click the "Fields…​" button while adding or
+To add and edit fields, click the **"Fields…​" button** while adding or
 editing notes. For more information on fields, please see the
 [Customizing Fields](editing.md#customizing-fields) section.
 
@@ -197,7 +197,7 @@ ensure related cards don't appear too close to each other, and they
 allow you to fix a typing mistake or factual error once and have all the
 related cards update at once.
 
-To add and edit card types, click the "Cards…​" button while adding or
+To add and edit card types, click the **"Cards…​" button** while adding or
 editing notes. For more information on card types, please see the [Cards and Templates](templates/intro.md) section.
 
 ### Note Types
@@ -225,7 +225,7 @@ types specifically for the content you are learning. The standard note types are
   front→back and back→front.
 
 - **Basic (optional reversed card)**\
-  Like "Basic", but has a third field called "Add Reverse". If you enter any text into
+  Like "Basic", but has a third field called **"Add Reverse"**. If you enter any text into
   that field, a reversed card (back→front) will also be created. For details, see the [Cards and Templates](templates/intro.md) section.
 
 - **Basic (type in the answer)**\
@@ -244,14 +244,14 @@ types specifically for the content you are learning. The standard note types are
   such as anatomy and geography. For details, please see the [Image Occlusion](editing.md#image-occlusion)
   section of the manual.
 
-To add your own note types and modify existing ones, you can use Tools →
-Manage Note Types from the main Anki window.
+To add your own note types and modify existing ones, you can use **Tools** →
+**Manage Note Types** from the main Anki **window**.
 
 Notes and note types are common to your whole collection rather than
 limited to an individual deck. This means you can use different
 note types in a single deck, or have cards generated from the
 same note put into different decks. When you add notes using the
-Add window, you can select what note type to use and what deck to use,
+**Add window**, you can select what note type to use and what deck to use,
 and these choices are completely independent of each other. You can also
 [change the note type of notes](browsing.md#notes) after you've already created them.
 
@@ -267,13 +267,12 @@ You can watch a video about [Shared Decks and Review Basics](http://www.youtube.
 The easiest way to get started with Anki is to download a deck of cards
 someone else has shared:
 
-1. Click the "Get Shared" button at the bottom of the deck list.
+1. Click the **"Get Shared" button** at the bottom of the **deck list**.
 
-2. When you've found a deck you're interested in, click the "Download"
-   button to download a deck package.
+2. When you've found a deck you're interested in, click the **"Download" button** to download a deck package.
 
 3. Double-click the downloaded package to import it into Anki, or go to
-   File → Import.
+   **File** → **Import**.
 
 Note: It’s not currently possible to add shared decks
 directly to your AnkiWeb account. You need to first import them to the

--- a/src/importing/intro.md
+++ b/src/importing/intro.md
@@ -2,4 +2,4 @@
 
 Anki can import text files, packaged Anki decks created by the export
 feature, Mnemosyne 2.0 .db files, and SuperMemo .xml files. To import a
-file, click the File menu and then "Import".
+file, click the **File menu** and then **"Import"**.

--- a/src/importing/intro.md
+++ b/src/importing/intro.md
@@ -2,4 +2,4 @@
 
 Anki can import text files, packaged Anki decks created by the export
 feature, Mnemosyne 2.0 .db files, and SuperMemo .xml files. To import a
-file, click the **File menu** and then **"Import"**.
+file, click **File** > **Import**.

--- a/src/importing/packaged-decks.md
+++ b/src/importing/packaged-decks.md
@@ -16,7 +16,7 @@ If you encounter imported cards with unexpectedly large intevals, the deck autho
 accidentally have included their scheduling information. You can use the
 [Set Due Date feature](../browsing.md#cards) to reset the imported cards. On Anki
 23.10 and later, you can remove any scheduling information during the import process
-by leaving the "**Import any learning progress** option" unselected. This will also remove
+by leaving the "Import any learning progress" option unselected. This will also remove
 any "leech" or "marked" tags from the imported cards.
 
 ## Updating

--- a/src/importing/packaged-decks.md
+++ b/src/importing/packaged-decks.md
@@ -16,7 +16,7 @@ If you encounter imported cards with unexpectedly large intevals, the deck autho
 accidentally have included their scheduling information. You can use the
 [Set Due Date feature](../browsing.md#cards) to reset the imported cards. On Anki
 23.10 and later, you can remove any scheduling information during the import process
-by leaving the "Import any learning progress" option unselected. This will also remove
+by leaving the "**Import any learning progress** option" unselected. This will also remove
 any "leech" or "marked" tags from the imported cards.
 
 ## Updating

--- a/src/importing/text-files.md
+++ b/src/importing/text-files.md
@@ -18,11 +18,11 @@ are met.
   records contain extra fields, the extra content will not be imported.
 
 - Anki tries to guess which field separator (commas, tabs, etc.) your file uses. 
-  If it guesses wrongly, you can change it in the import options window and preview 
+  If it guesses wrongly, you can change it in the **import options window** and preview
   the results. Or you can add [file headers](#file-headers) to force a specific field separator.
 
 Fields in your text file can be mapped to any field in your notes,
-including the tags field. You can choose which field in the text file
+including the **tags field**. You can choose which field in the text file
 corresponds to which field in the note when you import.
 
 When you import a text file, you can choose what deck to put the cards
@@ -60,15 +60,14 @@ file for you, it will automatically take care of escaping double quotes.
     hello; this is<br>a two line answer
     two; this is a one line one
 
-You need to turn on the **Allow HTML in fields** in the import
-dialog for HTML newlines to work.
+You need to turn on the **"Allow HTML in fields"** in the **import dialog** for HTML newlines to work.
 
 Escaped multi-lines will not work correctly if you are using cloze
 deletions that span multiple lines. In this case, please use HTML
 newlines instead.
 
-You can also include tags in another field and select it as a tags field
-in the import dialog:
+You can also include tags in another field and select it as a **tags field**
+in the **import dialog**:
 
     first field;second field;tags
 
@@ -89,7 +88,7 @@ to keep using Excel, please see [this doc](https://docs.google.com/document/d/12
 for more information.
 
 To save your spreadsheet to a file Anki can read with LibreOffice, go to
-**File &gt; Save As**, and then select CSV for the type of file. After
+**File** > **Save As**, and then select CSV for the type of file. After
 accepting the default options, LibreOffice will save the file and you
 can then import the saved file into Anki.
 
@@ -98,8 +97,7 @@ can then import the saved file into Anki.
 Anki can treat text imported from text files as HTML (the language used
 for web pages). This means that text with bold, italics and other
 formatting can be exported to a text file and imported again. If you
-want to include HTML formatting, you can check the "allow HTML in
-fields" checkbox when importing. You may wish to turn this off if you’re
+want to include HTML formatting, you can check the **"allow HTML in fields" checkbox** when importing. You may wish to turn this off if you’re
 trying to import cards whose content contains angle brackets or other
 HTML syntax.
 
@@ -131,10 +129,10 @@ Alternatively, you can use the [find and replace](../browsing.md) feature
 in the browse screen to update all the fields at once. If each field
 contains text like "myaudio", and you wish to make it play a sound,
 you’d search for (.\*) and replace it with "\[sound:\\1.mp3\]", with the
-**regular expressions** option enabled.
+**"regular expressions" option** enabled.
 
 When importing a text file with these references, you must make sure to
-enable the "Allow HTML" option.
+enable the **"Allow HTML" option**.
 
 You might be tempted to do this in a template, like:
 
@@ -162,20 +160,20 @@ note is unique. By default, if the file you are importing has a first
 field that matches one of the existing notes in your collection and that
 existing note is the same type as the type you’re importing, the
 existing note’s other fields will be updated based on content of the
-imported file. A drop-down box in the import screen allows you to change
+imported file. A **drop-down box** in the **import screen** allows you to change
 this behaviour, to either ignore duplicates completely, or import them
 as new notes instead of updating existing ones.
 
-The **match scope** setting controls how duplicates are identified. When
-**note type** is selected, Anki will identify a duplicate if another note
-with the same note type has the same first field. When set to **note type and deck**,
+The **"match scope" setting** controls how duplicates are identified. When
+**"note type"** is selected, Anki will identify a duplicate if another note
+with the same note type has the same first field. When set to **"note type and deck"**,
 a duplicate will only be flagged if the existing note also happens to be
 in the deck you are importing into.
 
 If you have updating turned on and older versions of the notes you’re
 importing are already in your collection, they will be updated in place
 (in their current decks) rather than being moved to the deck you have
-set in the import dialog. If notes are updated in place, the existing
+set in the **import dialog**. If notes are updated in place, the existing
 scheduling information on all their cards will be preserved.
 
 For info on how duplicates are handled in .apkg files, please see the

--- a/src/leeches.md
+++ b/src/leeches.md
@@ -9,7 +9,7 @@ Anki can help you identify leeches. Each time a review card "lapses" (is
 failed while it is in review mode), a counter increases. When this counter
 reaches 8, Anki tags the note as a leech and suspends the card. The 
 threshold, and whether to suspend or not, can be adjusted in the
-[deck options](deck-options.md).
+**[deck options](deck-options.md)**.
 
 If you keep failing that card, Anki will continue to alert you about the 
 leech periodically. These warnings occur at half the initial leech 

--- a/src/math.md
+++ b/src/math.md
@@ -20,8 +20,7 @@ To try it out:
 
 2. Select the text you just typed.
 
-3. Click the rightmost button in the editor, and choose "MathJax
-   inline" from the menu. Anki will change the text so it reads:
+3. Click the **rightmost button** in the **editor**, and choose **"MathJax inline"** from the **menu**. Anki will change the text so it reads:
 
        \(\sqrt{x}\)
 
@@ -83,7 +82,7 @@ LaTeX code can contain malicious commands that can read or write non-Anki
 data on your computer. For this reason, recent Anki versions will refuse to
 generate LaTeX images by default.
 
-If you wish to use LaTeX on your own cards, you will need to enable the **Generate LaTeX images** option in the preferences screen.
+If you wish to use LaTeX on your own cards, you will need to enable the **"Generate LaTeX images" option** in the **preferences screen**.
 
 **We strongly recommend you do not enable this option if you use shared decks, or think
 you will import shared decks in the future, as you are potentially giving any shared
@@ -104,9 +103,8 @@ LaTeX forum.
 To install LaTeX, on Windows use MiKTeX; on macOS use MacTeX, and on Linux
 use your distro’s package manager. Dvipng must also be installed.
 
-On Windows, go to Settings in MikTeX’s maintenance window, and make sure
-"Install missing packages on the fly" is set to "Always", not to "Ask me
-first". If you continue to have difficulties, one user reported that
+On Windows, go to **Settings** in MikTeX’s **maintenance window**, and make sure
+**"Install missing packages on the fly"** is set to **"Always"**, not to **"Ask me first"**. If you continue to have difficulties, one user reported that
 running Anki as an administrator until all the packages were fetched
 helped.
 
@@ -132,15 +130,15 @@ already exist, but can not generate the images on their own.
 
 To avoid having to review all your cards at least once before you can
 study on the other clients, Anki can generate the images in bulk for
-you. To generate all the images, please go to Tools&gt;Check Media.
+you. To generate all the images, please go to **Tools** > **Check Media**.
 After that, syncing should upload the generated media to AnkiWeb and the
 other clients.
 
 ### Example
 
 The most general way to input LaTeX content is to surround it with
-\[latex\]\[/latex\] tags. There’s a shortcut button for this documented
-in the [editor](editing.md) section.
+\[latex\]\[/latex\] tags. There’s a **shortcut button** for this documented
+in the **[editor](editing.md) section**.
 
 \[latex\] tags must be used inside a field - placing them in the card
 template will [cause problems](templates/fields.md).
@@ -223,9 +221,9 @@ want to put code like the above into a .latex file and test if you can
 compile it from the command line. Once you’ve confirmed that the package
 is available and working, we can integrate it with Anki.
 
-To use the package with Anki, click "Add" in the main window, then click
-the note type selection button. Click the "Manage" button, then select
-the note type you plan to use and click "Options". The LaTeX header and
+To use the package with Anki, click **"Add"** in the **main window**, then click
+the **note type selection button**. Click the **"Manage" button**, then select
+the note type you plan to use and click **"Options"**. The LaTeX header and
 footer are shown. The header will look something like:
 
     \documentclass[12pt]{article}
@@ -294,7 +292,7 @@ will (and LaTeX ignores spaces in math mode, so your equation will
 render the same). If you want to avoid adding the extra space into the
 rendered text (for example, when you are making Cloze cards for learning
 programming languages), another option is to use a HTML comment when
-editing the card in HTML mode:
+editing the card in **HTML mode**:
 
     {{c1::[$]\frac{foo}{\frac{bar}{baz}<!-- -->}[/$] blah blah blah.}}
 

--- a/src/media.md
+++ b/src/media.md
@@ -2,24 +2,24 @@
 
 Anki stores the sounds and images used in your notes in a folder next to
 the collection. For more on the folder location, please see the [file locations](files.md#file-locations) section. When you add media within Anki, either by
-using the paperclip icon in the [editor](editing.md) or by pasting it into
+using the **paperclip icon** in the **[editor](editing.md)** or by pasting it into
 a field, Anki will copy it from its original location into the media
 folder. This makes it easy to back up your collection’s media or move it
 to another computer.
 
 If your media filenames contain spaces or other special characters such
-as percentage signs, the way the filenames appear in the HTML editor will
+as percentage signs, the way the filenames appear in the **HTML editor** will
 differ from the way the filenames appear on disk. For example, a file called
-`hello 100%.jpg` will appear as `hello%20100%25.jpg` in the HTML editor.
+`hello 100%.jpg` will appear as `hello%20100%25.jpg` in the **HTML editor**.
 Internally, Anki still uses the original filenames, so if you would like to
 [search](searching.md) for the file or modify the filename with [Find&Replace](browsing.md#find-and-replace), you will
 need to use the name as it appears on disk, not as it appears in the
-HTML editor. Exporting to a text file is another way to see the underlying
+**HTML editor**. Exporting to a text file is another way to see the underlying
 representation.
 
 ## Checking Media
 
-You can use the Tools&gt;Check Media menu option to scan your notes and
+You can use the **Tools** > **Check Media menu option** to scan your notes and
 media folder. It will generate a report of files in the media folder
 that are not used by any notes, and media referenced in notes but
 missing from your media folder. It also allows you:
@@ -46,7 +46,7 @@ removing characters that won't work on certain operating systems,
 and truncating very long filenames.
 
 If you manually add files to your [media folder](files.md#file-locations),
-you should use Tools&gt;Check Media afterwards, to ensure the filenames are
+you should use **Tools** > **Check Media** afterwards, to ensure the filenames are
 encoded correctly. If you skip this step, any filenames that are not compatible
 will be skipped when syncing.
 

--- a/src/misc.md
+++ b/src/misc.md
@@ -14,13 +14,13 @@ for more information.
 
 ## Debug Console
 
-Sometimes you may be asked to use the debug console to change a setting
-or check something. Unless asked to enter text in the "debug console",
+Sometimes you may be asked to use the **debug console** to change a setting
+or check something. Unless asked to enter text in the **"debug console"**,
 you will probably not need this. Advanced users may like to read more
 about it in the [add-on writing guide](https://addon-docs.ankiweb.net/debugging.html#debug-console).
 
-When asked to enter text into the "debug console", please start Anki,
-and in the main window, press
+When asked to enter text into the **"debug console"**, please start Anki,
+and in the **main window**, press
 
 <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>;</kbd>
 
@@ -35,11 +35,11 @@ On a Mac, press
 On some non-English keyboards, you may need to press <kbd>:</kbd> or <kbd>+</kbd> instead
 of <kbd>;</kbd>.
 
-In the window that has popped up, please paste the text you were asked
-to paste in the top section. When you’ve done so, please press
+In the **window** that has popped up, please paste the text you were asked
+to paste in the **top section**. When you’ve done so, please press
 Ctrl+Return (Command+Return on a Mac), and some text should appear in
-the bottom section. If you’ve been asked to paste the resulting output,
-please copy it from the bottom area, and paste it back to the support
+the **bottom section**. If you’ve been asked to paste the resulting output,
+please copy it from the **bottom area**, and paste it back to the support
 person.
 
 If you press <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>Return</kbd> instead of just <kbd>Ctrl</kbd>+<kbd>Return</kbd>, Anki will

--- a/src/platform/linux/blank-window.md
+++ b/src/platform/linux/blank-window.md
@@ -1,6 +1,6 @@
 # Blank Main Window
 
-Some Linux distros have recently updated glibc. Recent versions break the web toolkit that Anki is built on, causing Anki's main window to appear blank.
+Some Linux distros have recently updated glibc. Recent versions break the web toolkit that Anki is built on, causing Anki's **main window** to appear blank.
 
 There are two ways to work around this:
 

--- a/src/platform/linux/display-issues.md
+++ b/src/platform/linux/display-issues.md
@@ -4,9 +4,9 @@ Hardware acceleration defaults to on. If you experience blank screens
 or display issues, you can try enabling software rendering.
 
 ### Changing the Driver From the Preferences Screen
-In Anki 23.10+, you can change the graphics driver from preferences screen by
+In Anki 23.10+, you can change the graphics driver from **preferences screen** by
 navigating to **Tools → Preferences** and then selecting the driver from the
-dropdown menu.
+**dropdown menu**.
 
 ### Changing the Driver From the Terminal
 ```

--- a/src/platform/linux/wayland.md
+++ b/src/platform/linux/wayland.md
@@ -6,4 +6,4 @@ displays, but it is currently off by default, due to the following issues:
 
 - On some distros, windows are rendered without borders.
 - Bringing windows to the front is not possible, so for example, clicking on Add
-  to reveal an existing Add Cards window will not work.
+  to reveal an existing **Add Cards window** will not work.

--- a/src/platform/mac/display-issues.md
+++ b/src/platform/mac/display-issues.md
@@ -6,12 +6,12 @@
 
 ### Changing the Driver From the Preferences Screen
 If you're experiencing display issues or crashes in Anki 23.10+, you can try
-changing the video driver in the preferences screen by navigating to **Anki →
-Preferences** and then selecting the driver from the dropdown menu. After that it
+changing the video driver in the **preferences screen** by navigating to **Anki →
+Preferences** and then selecting the driver from the **dropdown menu**. After that it
 is necessary to restart Anki.
 
 ### Changing the Driver From Terminal.app
-Older Anki versions did not provide an option in the preferences, but allowed
+Older Anki versions did not provide an option in the **preferences screen**, but allowed
 you to adjust the driver by opening Terminal.app, then pasting the following and hit enter:
 
 ```
@@ -25,7 +25,7 @@ remove that file.
 
 ## eGPUs
 
-If you experience blank screens when using an external graphics card on a Mac, you can ctrl+click on the Anki app, click "Get Info", and enable the "prefer eGPU" option.
+If you experience blank screens when using an external graphics card on a Mac, you can ctrl+click on the Anki app, click **"Get Info"**, and enable the **"prefer eGPU" option**.
 
 ## Monitors with Different Resolutions
 

--- a/src/platform/windows/display-issues.md
+++ b/src/platform/windows/display-issues.md
@@ -10,9 +10,9 @@ windows, and so on. Which one works best will depend on your computer.
 
 
 ## Changing the Driver From the Preferences Screen
-In Anki 23.10+, you can change the graphics driver from preferences screen by
+In Anki 23.10+, you can change the graphics driver from **preferences screen** by
 navigating to **Tools → Preferences** and then selecting the driver from the
-dropdown menu.
+**dropdown menu**.
 
 
 ## Changing the Driver From the Command Line
@@ -36,7 +36,7 @@ To revert to the default behaviour, change `software` to `auto`, or delete that 
 
 Anki 2.1.50+ comes with a full screen mode, but due to various issues, it had to
 be disabled while `OpenGL` is used. Turning on software rendering as described
-above will allow the full screen option to be used, though please bear in mind
+above will allow the **full screen option** to be used, though please bear in mind
 that rendering performance may suffer.
 
 In Anki 23.10+, full screen mode is supported with the default Direct3D driver.

--- a/src/platform/windows/installing.md
+++ b/src/platform/windows/installing.md
@@ -20,7 +20,7 @@ To install Anki:
 2. Save the installer to your desktop or downloads folder.
 3. Double-click on the installer to run it. If you see an error
    message, please see the [installation issues page](installation-issues.md).
-4. Once Anki is installed, double-click on the new star icon on your
+4. Once Anki is installed, double-click on the new **star icon** on your
    desktop to start Anki.
 
 ## Upgrading

--- a/src/platform/windows/permission-problems.md
+++ b/src/platform/windows/permission-problems.md
@@ -8,7 +8,7 @@ If you receive "access denied" messages, some of Anki's files may be set to read
 
 To fix the problem, you can do the following:
 
-- in the search area of the start bar, type cmd.exe and hit enter
+- in the **search area** of the **start bar**, type cmd.exe and hit enter
 - in the window that opens, type the following and hit enter to see your username:
 
 whoami

--- a/src/platform/windows/startup-issues.md
+++ b/src/platform/windows/startup-issues.md
@@ -25,7 +25,7 @@ When starting Anki, you may receive a message like the following:
 These errors are usually because your computer is missing a Windows update
 or Windows library.
 
-Please open Windows update, and ensure your system has all updates installed.
+Please open **Windows update**, and ensure your system has all updates installed.
 If any needed to be installed, please restart your device after installing.
 
 ## Windows 7/8
@@ -55,7 +55,7 @@ to see if it helps.
 ## Admin access
 
 Some users have reported that Anki did not run for them until they right-clicked
-on the Anki icon and chose "Run as administrator". Anki stores all of its data in
+on the **Anki icon** and chose **"Run as administrator"**. Anki stores all of its data in
 your user folder, and should not need administrator privileges, but it's something
 you can try if you've exhausted other options.
 
@@ -65,14 +65,14 @@ If the update process leaves you with multiple Anki installs (such as within
 `C:\Program Files\Anki` and `C:\Program Files (x86)\Anki`), they may be left in a
 non-working state, and Anki may refuse to start without showing an error message.
 
-Try uninstalling all copies of Anki from your computer. To do this, find them in Windows Settings > Apps & features (or Apps > Installed apps) and uninstall, or run `uninstall.exe` in each Anki program
+Try uninstalling all copies of Anki from your computer. To do this, find them in **Windows Settings** > **Apps & features** (or **Apps** > **Installed apps**) and uninstall, or run `uninstall.exe` in each Anki program
 folder. Afterward, install Anki again.
 
 ## Debugging
 
 Starting Anki from a terminal may reveal a bit more information about some
 errors. After installing the latest Anki version and ensuring all Windows
-updates are installed, instead of running Anki directly, press the <kbd>Windows</kbd> key (or open the Start menu), type `cmd`, and launch Command Prompt. When the terminal window opens, paste the following command, and press <kbd>Enter</kbd>. (The path will be different if Anki is installed in a location that is not the default.)
+updates are installed, instead of running Anki directly, press the <kbd>Windows</kbd> key (or open the **Start menu**), type `cmd`, and launch **Command Prompt**. When the **terminal window** opens, paste the following command, and press <kbd>Enter</kbd>. (The path will be different if Anki is installed in a location that is not the default.)
 
 ```
 %LocalAppData%\Programs\Anki\anki-console.bat

--- a/src/platform/windows/text-size.md
+++ b/src/platform/windows/text-size.md
@@ -6,8 +6,8 @@ variables you can try:
 - ANKI_NOHIGHDPI=1 will turn off some of Qt’s high dpi support
 
 - ANKI_WEBSCALE=1 will alter the scale of Anki’s web views (like the
-  deck list, study screen, etc), while leaving interface elements like
-  the menu bar alone. Replace 1 with the desired scale, such as 1.5 or
+  **deck list**, **study screen**, etc), while leaving interface elements like
+  the **menu bar** alone. Replace 1 with the desired scale, such as 1.5 or
   0.75.
 
 On Windows you can add these to a batch file to make it easier to start

--- a/src/preferences.md
+++ b/src/preferences.md
@@ -40,10 +40,10 @@ Note: If you're on Windows, please check [this page](./platform/windows/display-
 
 These options allow you to remove some unnecessary elements from the screen during reviews. You can:
 
-- Hide the top and bottom bar during reviews.
-- Enable the "minimalist" mode, making the interface more compact/less fancy.
-- Reduce motion, to disable some transitions/animations.
-- Switching between native styling and the Anki theme (only on Mac/Linux).
+- **Hide the top and bottom bar during reviews**.
+- **Enable the "minimalist" mode**, making the interface more compact/less fancy.
+- **Reduce motion**, to disable some transitions/animations.
+- **Switching between native styling and the Anki theme** (only on Mac/Linux).
 
 ## Review
 
@@ -75,7 +75,7 @@ cards you’ve managed to study during the prescribed time limit.
 ### Review
 
 **Show play buttons on cards with audio**\
-Whether a clickable (re)play button will be shown in the study screen
+Whether a clickable (re)play **button** will be shown in the **study screen**
 for cards with audio.
 
 **Interrupt current audio when answering**\
@@ -83,7 +83,7 @@ Whether a currently playing audio file should be stopped when answering
 a card.
 
 **Show remaining card count**\
-Disable this option to hide the card count at the bottom of the screen.
+Disable this option to hide the card count at the bottom of the **screen**.
 
 **Show next review time above answer buttons**\
 Useful to know how far in the future your cards are being pushed.
@@ -106,22 +106,21 @@ By default, formatting like bold and colors are kept when pasting,
 unless the <kbd>Shift</kbd> key is held down. This option reverses the behaviour.
 
 **Default deck**\
-Controls how note types and decks interact. The default of "When adding, default
-to current deck" means that Anki saves the last-used note type for each deck and
+Controls how note types and decks interact. The default of "**When adding, default to current deck**" means that Anki saves the last-used note type for each deck and
 selects it again then next time you choose the deck (and, in addition, will
-start with the current deck selected when choosing Add from anywhere). The other
-option, "Change deck depending on note type," saves the last-used deck for each
-note type (and opens the add window to the last-used note type when you choose
-Add). This may be more convenient if you always use a single note type for each
+start with the current deck selected when choosing **Add** from anywhere). The other
+option, "**Change deck depending on note type**," saves the last-used deck for each
+note type (and opens the **add window** to the last-used note type when you choose
+**Add**). This may be more convenient if you always use a single note type for each
 deck.
 
 The last used deck/note type is updated when you add a card. If you change the deck
-and close the add window without adding a card, it won't be saved.
+and close the **add window** without adding a card, it won't be saved.
 
 ### Browsing
 
 **Default search text**\
-Allows you to customize the starting search text in the browser (eg, to start
+Allows you to customize the starting search text in the **browser** (eg, to start
 with "deck:current").
 
 **Ignore accents in search (slower)**\
@@ -149,7 +148,7 @@ with an older version that is on AnkiWeb.
 
 ### AnkiWeb Account
 
-When logged in, clicking on Log Out will log you out.
+When logged in, clicking on **Log Out** will log you out.
 
 ### Self-hosted Sync Server
 

--- a/src/profiles.md
+++ b/src/profiles.md
@@ -3,7 +3,7 @@
 If more than one person wants to use Anki on your computer, you can set
 up a separate profile for each user. Each user profile has their own
 collection, and own program settings. Add-ons are shared across profiles.
-Profiles are configured by going to the File menu and choosing "Switch Profile".
+Profiles are configured by going to the **File menu** and choosing "**Switch Profile**".
 
 **Only a single profile can be synced to an AnkiWeb account.**
 If you have different users on your computer, each user will
@@ -22,10 +22,10 @@ AnkiDroid does not support profiles.
 
 ## Profiles window
 
-From the Profiles window (accessible via File>Switch Profile from the main window), you can:
+From the **Profiles window** (accessible via **File** > **Switch Profile** from the main window), you can:
 
-- Open / Add / Rename / Delete user profiles.
-- Quit the program.
+- **Open** / **Add** / **Rename** / **Delete** user profiles.
+- **Quit** the program.
 - Restore an [automatic backup.](./backups.md)
 - Downgrade your collection, which is necessary if you want to open it with
   an earlier Anki release. If you skip this step, you may get an error message

--- a/src/searching.md
+++ b/src/searching.md
@@ -2,12 +2,12 @@
 
 <!-- toc -->
 
-Anki's Browse screen and the Filtered Deck feature use a common method
+Anki's **Browse screen** and the Filtered Deck feature use a common method
 of searching for specific cards/notes. This method can also be used to adjust the scope of FSRS optimization. 
 
 ## Simple searches
 
-When you type some text into the search box, Anki finds matching notes
+When you type some text into the **search box**, Anki finds matching notes
 and displays their cards. Anki searches in all fields of the notes, but
 does not search for tags (see [later in this section](#tags-decks-cards-and-notes) to search for tags). Some examples:
 
@@ -219,7 +219,7 @@ Some things to be aware of:
 
 - The search is case-insensitive by default; use `(?-i)` at the start to turn on case sensitivity.
 - Some text like spaces and newlines may be represented differently in HTML - you can
-  use the HTML editor in the editing screen to see the underlying HTML contents.
+  use the **HTML editor** in the **editing screen** to see the underlying HTML contents.
 - For the specifics of Anki's regex support, see the [regex crate documentation](<https://docs.rs/regex/1.3.9/regex/#syntax>).
 
 ## Card state
@@ -450,8 +450,8 @@ the note with note id 123.
 `cid:123,456,789`\
 all cards with card ids 123, 456, or 789.
 
-Note and card IDs can be found in the [card info](stats.md) dialog in the
-browser. These searches may also be helpful when doing add-on
+Note and card IDs can be found in the **[card info](stats.md) dialog** in the
+**browser**. These searches may also be helpful when doing add-on
 development or otherwise working closely with the database.
 
 ## Custom Data

--- a/src/stats.md
+++ b/src/stats.md
@@ -4,7 +4,7 @@
 
 ## Card Info
 
-You can display information about a card by using the Cards&gt;Info menu item,
+You can display information about a card by using the **Cards** > **Info menu item**,
 by right-clicking on the card and then selecting **Info**, or by pressing
 <kbd>I</kbd> on the study screen.
 
@@ -29,7 +29,7 @@ card with the "Good" button.
 
 The bottom section shows the review history for the card. Rating denotes
 the button (1 = Again, 4 = Easy). When cards are manually rescheduled using
-the "reset" or "set due date" actions, the type will be listed as Manual
+the **"reset"** or **"set due date" actions**, the type will be listed as Manual
 and the rating as 0.
 
 ## Statistics
@@ -45,12 +45,12 @@ top of the main window, or by pressing <kbd>T</kbd>.
 
 By default, the statistics window will show statistics from the currently selected deck and any
 subdecks it may contain, but you can select any deck from your collection by typing its name in the
-text box at the top of the screen or (from Anki 2.1.61), by using the deck selector at the bottom.
+**text box** at the top of the **screen** or (from Anki 2.1.61), by using the **deck selector** at the bottom.
 
 ### Collection
 
-If you select this checkbox, statistics will be shown for your entire collection. You can also display graphs
-for arbitrary searches by adding filters in the search box at the top (2.1.28+).
+If you select this **checkbox**, statistics will be shown for your entire collection. You can also display graphs
+for arbitrary searches by adding filters in the **search box** at the top (2.1.28+).
 
 ### History
 
@@ -60,7 +60,7 @@ You can change this to all history scope or deck life scope at the top. (The
 
 ### More
 
-- Clicking on "Save PDF" at the bottom will save a PDF document of the statistics to a file
+- Clicking on **"Save PDF"** at the bottom will save a PDF document of the statistics to a file
   on your desktop to make it easy to share your statistics with others.
 
 - When you delete notes, their review history is maintained in Anki. It

--- a/src/studying.md
+++ b/src/studying.md
@@ -10,24 +10,23 @@ to start studying.
 Study in Anki is limited to the currently selected deck as well as any
 subdecks it contains.
 
-On the decks screen, your decks and subdecks will be displayed in a list. [New, Learn, and Due (To Review)](getting-started.md#card-states)
+On the **decks screen**, your decks and subdecks will be displayed in a list. [New, Learn, and Due (To Review)](getting-started.md#card-states)
 cards for that day will be also displayed here.
 
 ![Decks screen](media/decks_screen.png)
 
 When you click on a deck, it will become the "current deck", and Anki
-will change to the study screen. You can return to the deck list at any time by clicking on “Decks” at
-the top of the main window. (You can also use the Study
-Deck action in the menu to select a new deck from the keyboard, or you
+will change to the **study screen**. You can return to the **deck list** at any time by clicking on **“Decks”** at
+the top of the main window. (You can also use the **Study Deck** action in the menu to select a new deck from the keyboard, or you
 can press the <kbd>s</kbd> key to study the currently selected deck.)
 
-You can click the gears button to the right of a deck to rename or
+You can click the **gears** button to the right of a deck to rename or
 delete the deck, change its [options](deck-options.md), or [export](exporting.md) it.
 
 ## Study Overview
 
 After clicking on a deck to study, you’ll see a screen that shows you
-how many cards are due today. This is called the "deck overview" screen:
+how many cards are due today. This is called the **"deck overview" screen**:
 
 ![Study overview](media/study_overview.png)
 
@@ -91,38 +90,37 @@ is not possible to turn this feature off.
 ## Editing and More
 
 You can click the **Edit** button in the bottom left to edit the current
-note. When you finish editing, you’ll be returned to study. The editing
-screen works very similarly to the [add notes](editing.md) screen.
+note. When you finish editing, you’ll be returned to study. The **editing screen** works very similarly to the **[add notes](editing.md) screen**.
 
-At the bottom right of the study screen is a button labeled **More**.
+At the bottom right of the **study screen** is a button labeled **More**.
 This button provides some other operations you can do on the current
 card or note:
 
-- [**Flag Card**](editing.md#using-flags): Adds a colored marker to the card, or toggles it off. Flags will appear during
-  study, and you can search for flagged cards in the Browse screen. This is useful
+- **Flag Card**: Adds a colored marker to the card, or toggles it off. Flags will appear during
+  study, and you can search for flagged cards in the **Browse screen**. This is useful
   when you want to take some action on the card at a later date, such as looking
   up a word when you get home. If you're using Anki 2.1.45+, you can also rename flags
-  from the [browser](browsing.md).
+  from the **[browser](browsing.md)**.
 
 - **Bury Card / Note**: Hides a card or all of the note’s cards from review until the next day.
-  (If you want to unbury cards before then, you can click the “unbury”
-  button on the [deck overview](studying.md#study-overview) screen.) This is useful if
+  (If you want to unbury cards before then, you can click the **“unbury”**
+  button on the **[deck overview](studying.md#study-overview) screen**.) This is useful if
   you cannot answer the card at the moment or you want to come back to it
   another time. Burying can also [happen automatically](studying.md#siblings-and-burying) for
   cards of the same note.
 
 - **Reset card**: Moves the current card to [the end of the new queue](browsing.md#cards).
 
-  The "Restore original position" option allows you to reset the card back to its original position when you reset it.
+  The **"Restore original position"** option allows you to reset the card back to its original position when you reset it.
 
-  The "Reset repetition and lapse count" option, if enabled, will set the review and failure counters
+  The **"Reset repetition and lapse count"** option, if enabled, will set the review and failure counters
   for the card back to zero. It does not remove the review history that is shown at the bottom of the
-  card info screen.
+  **card info screen**.
 
 - **Set Due Date**: Puts cards in the review queue, and [makes them due on a certain date.](browsing.md#cards)
 
 - **Suspend Card / Note**: Hides a card or all of the note’s cards from review until they are
-  manually unsuspended (by clicking the suspend button in the browser).
+  manually unsuspended (by clicking the **suspend button** in the **browser**).
   This is useful if you want to avoid reviewing the note for some time,
   but don’t want to delete it.
 
@@ -132,13 +130,13 @@ card or note:
 
 - **Previous Card Info**: Displays [statistical information](stats.md#card-info) about the previous card.
 
-- [**Mark Note**](editing.md#the-marked-tag): Adds a “marked” tag to the current note, so it can be easily found in the
-  browser. This is similar to flagging individual cards, but works with a tag
+- **Mark Note**: Adds a “marked” tag to the current note, so it can be easily found in the
+  **browser**. This is similar to flagging individual cards, but works with a tag
   instead, so if the note has multiple cards, all cards will appear in a search
   for the marked tag. Most users will want to use flags instead.
 
 - **Create Copy**: Opens a [duplicate](browsing.md#finding-duplicates) of the current
-  note in the editor, which can be slightly modified to easily obtain variations of your cards.
+  note in the **editor**, which can be slightly modified to easily obtain variations of your cards.
   By default, the duplicate card will be created in the same deck as the original.
 
 - **Delete Note**: Deletes the note and all of its cards.
@@ -152,7 +150,7 @@ card or note:
 - **Record Own Voice**: Record from your microphone for the purposes of checking your
   pronunciation. This recording is temporary and will go away when you
   move to the next card. If you want to add audio to a card permanently,
-  you can do that in the edit window.
+  you can do that in the **edit window**.
 
 - **Replay Own Voice**: Replay the previous recording of your voice (presumably after showing
   the answer).
@@ -185,7 +183,7 @@ Since cards in learning are somewhat time-critical, they are fetched
 from all decks at once and shown in the order they are due.
 
 To control the order cards appear in, see [Display Order](./deck-options.md#display-order). For more fine-grained ordering of new cards, you
-can change the order in the [browser](browsing.md).
+can change the order in the **[browser](browsing.md)**.
 
 ## Siblings and Burying
 
@@ -197,8 +195,8 @@ These related cards are called "siblings".
 When you answer a card that has siblings, Anki can prevent the card’s
 siblings from being shown in the same session by automatically "burying"
 them. Buried cards are hidden from review until the clock rolls over to
-a new day or you manually unbury them using the “Unbury” button that’s
-visible at the bottom of the [deck overview](studying.md#study-overview) screen. Anki
+a new day or you manually unbury them using the **“Unbury” button** that’s
+visible at the bottom of the **[deck overview](studying.md#study-overview) screen**. Anki
 will bury siblings even if the siblings are not in the same deck (for
 instance, if you use the [deck override](templates/intro.md) feature).
 
@@ -226,9 +224,9 @@ You can use the <kbd>1</kbd>-<kbd>4</kbd> keys to select a specific ease button.
 find it convenient to answer most cards with <kbd>Space</kbd> and keep one finger
 on <kbd>1</kbd> for when they forget.
 
-The "Study Deck" item in the Tools menu allows you to quickly switch to
+The **"Study Deck" item** in the **Tools menu** allows you to quickly switch to
 a deck with the keyboard. You can trigger it with the <kbd>/</kbd> key. When
-opened, it will display all of your decks and show a filter area at the
+opened, it will display all of your decks and show a **filter area** at the
 top. As you type characters, Anki will display only decks matching the
 characters you type. You can add a space to separate multiple search
 terms, and Anki will show only decks that match all the terms. So “ja 1”

--- a/src/sync-server.md
+++ b/src/sync-server.md
@@ -134,7 +134,7 @@ that the server binds to.
 
 You'll need to determine your computer's network IP address, and then
 point each of your Anki clients to the address, e.g something like
-`http://192.168.1.200:8080/`. The URL can be configured in the preferences.
+`http://192.168.1.200:8080/`. The URL can be configured in the **preferences screen**.
 
 If you're using AnkiMobile and are unable to connect to a server on your local
 network, please go into the iOS settings, locate Anki near the bottom, and

--- a/src/syncing.md
+++ b/src/syncing.md
@@ -14,8 +14,8 @@ For a quick introduction to syncing, please check out the
 
 ## Setup
 
-To start syncing your collection across devices, click the sync button
-(the top right one on the [main screen](studying.md#decks), or press <kbd>Y</kbd> on your keyboard.
+To start syncing your collection across devices, click the **sync button**
+(the top right one on the **[main screen](studying.md#decks)**, or press <kbd>Y</kbd> on your keyboard.
 You’ll be prompted for your AnkiWeb ID and password, which you created
 in the signup process.
 
@@ -40,11 +40,11 @@ with a single AnkiWeb account, you will lose data.
 
 Once syncing is enabled, Anki will automatically sync each time your
 collection is closed or opened. If you would prefer to synchronize
-manually, you can disable automatic syncing in Anki’s [preferences.](preferences.md#syncing)
+manually, you can disable automatic syncing in Anki’s **[preferences.](preferences.md#syncing)**
 
 ## Button Color
 
-The sync button will change to blue when a normal sync is required,
+The **sync button** will change to blue when a normal sync is required,
 and red when a full sync is required.
 
 ## Media
@@ -63,7 +63,7 @@ To prevent accidental data loss, deletions will only sync to other devices if th
 media is fully in sync. If you delete files before your device is fully in sync, and the deleted
 files are already on AnkiWeb, they will be downloaded the next time you sync.
 
-If you have accidentally deleted media files, and want to restore them, open the preferences
+If you have accidentally deleted media files, and want to restore them, open the **preferences screen**
 and log out. The next time you sync, Anki will restore any deleted files, if they are available
 on AnkiWeb still.
 
@@ -111,15 +111,14 @@ behaviour of merging changes from both ends.
 
 If you wish to force a full upload or download (for example, because you
 accidentally deleted a deck on one side and want to restore the deck
-rather than having its deletion synchronized), you can check the "On
-next sync, force changes in one direction" box in
-**Tools &gt; Preferences &gt; Network**, then sync as usual. (You’ll be given
+rather than having its deletion synchronized), you can check the **"On next sync, force changes in one direction" box** in
+**Tools** > **Preferences** > **Network**, then sync as usual. (You’ll be given
 the option to choose which side you want to use.)
 
 Forcing a one way sync only affects card syncing - media is synced as
 normal. If you have files that you want to remove from AnkiWeb, please
 ensure your client is fully in sync first. After syncing is up to date,
-any files you remove (e.g. via the **Check Media** function) will be removed
+any files you remove (e.g. via the **Check Media function**) will be removed
 from AnkiWeb on the following sync.
 
 ## Merging Conflicts
@@ -131,10 +130,10 @@ if you overwrite it with the content from the other device. With some
 work, it is possible to manually merge data into a single collection.
 
 Start by taking a backup on each device/profile, in case something goes
-wrong. With the computer version you can use **File &gt; Export** to export
+wrong. With the computer version you can use **File** > **Export** to export
 "all decks" with scheduling information and media files included, and
-save the file somewhere safe. In AnkiMobile, the Add/Export button on
-the decks list screen will let you export all decks with media.
+save the file somewhere safe. In AnkiMobile, the **Add/Export button** on
+the **decks list screen** will let you export all decks with media.
 
 Next, if one of your devices is a mobile device, synchronize it first.
 If there’s a conflict, choose **Upload** to overwrite any existing data on
@@ -144,18 +143,18 @@ number of decks first.
 
 Now return to the other device/profile. If automatic syncing is enabled,
 a message may pop up asking if you want to upload or download. Click the
-cancel button - we don’t want to sync yet.
+**cancel button** - we don’t want to sync yet.
 
-Once you’re looking at the deck list, click the cog icon next to the
+Once you’re looking at the **deck list**, click the **cog icon** next to the
 first deck, and choose **Export**. Export the content with scheduling
 information and media included, and save the `.apkg` file somewhere. Now
 you’ll need to repeat this for each top-level deck.
 
-Once all top-level decks have been exported, click the sync button at
+Once all top-level decks have been exported, click the **sync button** at
 the top right, and choose **Download**, which will overwrite the local
 content with the content you synced from your other device.
 
-You can now use **File &gt; Import** to import the `.apkg` files you exported
+You can now use **File** > **Import** to import the `.apkg` files you exported
 earlier, which will merge the exported content with the existing
 content, so everything will be in one place.
 

--- a/src/templates/errors.md
+++ b/src/templates/errors.md
@@ -12,11 +12,11 @@ Please see [Key Concepts](../getting-started.md#key-concepts) before reading fur
 
 Most of the errors below will require you to modify your note type/card template. To do so:
 
-- Open the Browse screen, and look at the items on the left.
-- Locate the note type mentioned in error message. You can use the search bar at the top left
+- Open the **Browse screen**, and look at the items on the left.
+- Locate the note type mentioned in error message. You can use the **search bar** at the top left
   if necessary.
 - Click on the note type, to show its cards/notes on the right.
-- Click the Cards... button at the top of the editing area to open the [templates screen](./intro.md#the-templates-screen).
+- Click the **Cards... button** at the top of the **editing area** to open the **[templates screen](./intro.md#the-templates-screen)**.
 
 ## Specific Issues
 
@@ -25,10 +25,10 @@ Most of the errors below will require you to modify your note type/card template
 This kind of error indicates an incorrect usage of the [field replacement](./fields.md)
 syntax.
 
-You can correct mistakes on the template by opening the card templates screen:
+You can correct mistakes on the template by opening the **card templates screen**:
 
-- On the computer version, edit a problem card, and then click on the Cards... button
-- On AnkiMobile, while viewing a problem card in the study screen, tap the cog/gear, then Card Template.
+- On the computer version, edit a problem card, and then click on the **Cards... button**
+- On AnkiMobile, while viewing a problem card in the study screen, tap the **cog/gear**, then **Card Template**.
 
 When you correct a mistake, it will update all cards of that type - you do not need to make the same change for every card that uses the template.
 
@@ -100,8 +100,8 @@ You have Anki configured to create two identical questions for each input. This 
 happen if you add a new card type without making any adjustments to it. Identical
 cards double your workload, and make Anki's scheduling less effective.
 
-To fix this, open the [templates screen](./intro.md#the-templates-screen), and
-select one of the duplicates at the top. Then use the button on the top right to
+To fix this, open the **[templates screen](./intro.md#the-templates-screen)**, and
+select one of the duplicates at the top. Then use the **button** on the top right to
 remove the selected card type. This will delete all the duplicate cards/notes that
 were using the card type as well.
 
@@ -115,7 +115,7 @@ message that a card has a blank front, it means either none of the fields includ
 but none are included on the front template.
 You can fix this problem by editing the card on the computer version, clicking on **Cards...**,
 and checking to make sure at least one field with some text on it is included on the front template.
-You can add extra fields with the Add Field button.
+You can add extra fields with the **Add Field button**.
 
 If you are using the Cloze note type,
 please make sure you've included one or more cloze deletions in the Text field, e.g. {{c1::some cloze-deleted text}}.
@@ -149,13 +149,13 @@ and
 {{c1::This}} is a {{c2::sample}} {{c1::sentence}}.
 ```
 
-are both changes that would make card 3 blank. When you view card 3, you'll see a message indicating that the card is blank, and can be cleaned up with the Empty Cards function. You can access that function via the Tools menu of the computer version's main window, and use it to remove blank cards. Please check the reported empty cards first, and if in doubt, create a backup with the File>Export menu item before proceeding.
+are both changes that would make card 3 blank. When you view card 3, you'll see a message indicating that the card is blank, and can be cleaned up with the **Empty Cards function**. You can access that function via the **Tools menu** of the computer version's **main window**, and use it to remove blank cards. Please check the reported empty cards first, and if in doubt, create a backup with the **File** > **Export menu item** before proceeding.
 
 #### All cloze cards empty
 
 If you accidentally modify your card template, it may prevent any cloze deletions from appearing. If that has happened, please edit one such problem card, and note down the name of the first field - it is usually called "Text". Then, please:
 
-- Click on the Cards... button
+- Click on the **Cards... button**
 - Replace the front text with
 
   ```

--- a/src/templates/fields.md
+++ b/src/templates/fields.md
@@ -34,7 +34,7 @@ line, and then the Back field”.
 
 The "id=answer" part tells Anki where the divider is between the
 question and the answer. This allows Anki to automatically scroll to the
-spot where the answer starts when you press **show answer** on a long card
+spot where the answer starts when you press **Show Answer** on a long card
 (especially useful on mobile devices with small screens). If you don’t
 want a horizontal line at the beginning of the answer, you can use
 another HTML element such as a paragraph or div instead.
@@ -100,13 +100,13 @@ Both speed and voices are optional, but the language must be included.
 
 On a Mac, you can customize the available voices:
 
-- Open the System Preferences screen.
+- Open the **System Preferences screen**.
 
-- Click on Accessibility.
+- Click on **Accessibility**.
 
-- Click on Speech.
+- Click on **Speech**.
 
-- Click on the system voice dropdown, and choose Customize.
+- Click on the **system voice dropdown**, and choose **Customize**.
 
 Some voices sound better than others, so experiment to choose the one
 you prefer. Please note that the Siri voice can only be used by Apple
@@ -182,7 +182,7 @@ your template:
 
     {{hint:MyField}}
 
-This will show a link labeled “show hint”; when you click it, the
+This will show a link labeled **“show hint”**; when you click it, the
 content of the field will be displayed on the card. (If MyField is
 empty, nothing will be shown.)
 
@@ -345,8 +345,8 @@ see the [importing section](../importing/text-files.md#importing-media) for more
 You can watch [a video about this feature](http://www.youtube.com/watch?v=5tYObQ3ocrw&yt:cc=on) on
 YouTube.
 
-The easiest way to check your answer is to click "Basic" at the top
-left of the card adding screen, and select "Basic (type in the answer)".
+The easiest way to check your answer is to click **`Basic`** at the top
+left of the **card adding screen**, and select **`Basic (type in the answer)`**.
 
 If you have downloaded a shared deck and would like to type in the answer
 with it, you can modify its card template. If it has a template like:
@@ -371,9 +371,9 @@ will appear on the back as well.
 
 When reviewing, Anki will display a text box where you can type in the
 answer, and upon hitting <kbd>Enter</kbd> or showing the answer, Anki will show you
-which parts you got right and which parts you got wrong. The text box’s
+which parts you got right and which parts you got wrong. The **text box’s**
 font size will be the size you configured for that field (via the
-“Fields” button when editing).
+**“Fields” button** when editing).
 
 This feature does not change how the cards are answered, so it’s still
 up to you to decide how well you remembered or not.
@@ -386,7 +386,7 @@ comprised of multiple lines.
 Anki uses a monospaced font for the answer comparison so that the
 “provided” and “correct” sections line up. If you wish to override the
 font for the answer comparison, you can put the following at the bottom
-of your styling section:
+of your **styling section**:
 
     code#typeans { font-family: "myfontname"; }
 
@@ -399,7 +399,7 @@ classes "typeGood", "typeBad" and "typeMissed". AnkiMobile supports
 "typeGood" and "typeBad", but not "typeMissed".
 
 If you wish to override the size of the typing box and don’t want to
-change the font in the Fields dialog, you can override the default
+change the font in the **Fields dialog**, you can override the default
 inline style using `!important`, like so:
 
     #typeans { font-size: 50px !important; }
@@ -416,9 +416,9 @@ Note that since the cloze type does not use FrontSide, this must be
 added to both sides on a cloze note type.
 
 If there are multiple sections elided, you can separate the answers in
-the text box with a comma.
+the **text box** with a comma.
 
-Type answer boxes will not appear in the ["preview" dialog](intro.md) in the browser. When you review or look at
-the preview in the card types window, they will display.
+Type answer boxes will not appear in the **["preview" dialog](intro.md)** in the **browser**. When you review or look at
+the preview in the **card types window**, they will display.
 
 Type answer boxes will not be displayed when you review your cards on [ankiweb.net](../syncing.md).

--- a/src/templates/generation.md
+++ b/src/templates/generation.md
@@ -30,15 +30,14 @@ When you edit a previously added note, Anki will automatically create
 extra cards if they were previously blank but no longer are. If your
 edits have made some cards blank when they previously were not, however,
 Anki will not delete them immediately, as that could lead to accidental
-data loss. To remove the empty cards, go to Tools → Empty Cards in the
-main window. You will be shown a list of empty cards and be given the
+data loss. To remove the empty cards, go to **Tools** → **Empty Cards** in the
+**main window**. You will be shown a list of empty cards and be given the
 option to delete them.
 
 Because of the way that card generation works, it is not possible to
 manually delete individual cards, as they would just end up being recreated
 the next time the note was edited. Instead, you should make the
-relevant conditional replacement fields empty and then use the Empty
-Cards option.
+relevant conditional replacement fields empty and then use the **Empty Cards option**.
 
 Anki does not consider special fields or non-field text for the purposes
 of card generation. Thus if your front template looked like the

--- a/src/templates/intro.md
+++ b/src/templates/intro.md
@@ -27,28 +27,25 @@ used for styling web pages.
 
 On the right is a preview of the front and back of the currently
 selected card. If you opened the window while adding notes, the preview
-will be based on the text you had typed into the Add Notes window. If
+will be based on the text you had typed into the **Add Notes window**. If
 you opened the window while editing a note, the preview will be based on
-the content of that note. If you opened the window from Tools → Manage
-Note Types, Anki will display each field’s name in parentheses in place
+the content of that note. If you opened the window from **Tools** → **Manage Note Types**, Anki will display each field’s name in parentheses in place
 of content.
 
-At the top right of the window is an Options button that gives you
+At the top right of the window is an **Options button** that gives you
 options to rename or reorder the cards, as well as the following two
 options:
 
-- The **Deck Override** option allows you to change the deck that cards
+- The **Deck Override option** allows you to change the deck that cards
   generated from the current card type will be placed into. By
-  default, cards are placed into the deck you provide in the Add Notes
-  window. If you set a deck here, that card type will be placed into
-  the deck you specified, instead of the deck listed in the Add Notes
-  window. This can be useful if you want to separate cards into
+  default, cards are placed into the deck you provide in the **Add Notes window**. If you set a deck here, that card type will be placed into
+  the deck you specified, instead of the deck listed in the **Add Notes window**. This can be useful if you want to separate cards into
   different decks (for instance, when studying a language, to put
   production cards in one deck and recognition cards in another). You
   can check which deck the cards are currently going to by choosing
-  Deck Override again.
+  **Deck Override** again.
 
-- The **Browser Appearance** option allows you to set different (perhaps
-  simplified) templates for display in the Question and Answer columns
-  of the browser; see [browser appearance](styling.md#browser-appearance) for more
+- The **Browser Appearance option** allows you to set different (perhaps
+  simplified) templates for display in the **Question** and **Answer columns**
+  of the **browser**; see [browser appearance](styling.md#browser-appearance) for more
   information.

--- a/src/templates/styling.md
+++ b/src/templates/styling.md
@@ -9,7 +9,7 @@ The video shows Anki 2.0’s interface, but the concepts are largely the
 same.
 
 The styling section of the Cards screen can be accessed by clicking the
-"Styling" button next to the "Back Template" button. In that section,
+**"Styling" button** next to the **"Back Template" button**. In that section,
 you can change the background color of the card, the default font, the
 text alignment, and so on.
 
@@ -97,7 +97,7 @@ You can explore the styling of cards interactively by using Chrome:
 
 <https://addon-docs.ankiweb.net/porting2.0.html#webview-changes>
 
-Anki 2.1.50+ supports image resizing within the editor natively.
+Anki 2.1.50+ supports image resizing within the **editor** natively.
 
 ## Field Styling
 
@@ -191,7 +191,7 @@ When audio or text to speech is included on your cards, Anki will show
 buttons you can click on to replay the audio.
 
 If you prefer not to see the buttons, you can hide them in the
-preferences screen.
+**preferences screen**.
 
 You can customize their appearance in your card styling, for example, to
 make them smaller and colored, you could use the following:
@@ -226,7 +226,7 @@ of only certain fields by wrapping their references in some HTML:
 
     <div dir="rtl">{{Front}}</div>
 
-To change the direction of fields in the editor, please see
+To change the direction of fields in the **editor**, please see
 the [editing](../editing.md#customizing-fields) section.
 
 ## Other HTML
@@ -245,12 +245,12 @@ web if you’d like to learn more.
 ## Browser Appearance
 
 If your card templates are complex, it may be difficult to read the
-question and answer columns (called "Front" and "Back") in the [card list](../browsing.md#cardnote-table). The "browser appearance" option allows you to define a
-custom template to be used only in the browser, so you can include only
+**Question** and **Answer columns** (called "Front" and "Back") in the **[card list](../browsing.md#cardnote-table)**. The **"browser appearance" option** allows you to define a
+custom template to be used only in the **browser**, so you can include only
 the important fields and change the order if you desire. The syntax is
 the same as in standard card templates.
 
-When using this option, if the text in the question column is repeated at the beginning of the answer column, Anki will display the text only in the question column. For example, if the question column text is "People in Ladakh speak", and the answer is "People in Ladakh speak Ladakhi", the answer column will only display "Ladakhi", omitting the rest.
+When using this option, if the text in the **Question column** is repeated at the beginning of the **Answer column**, Anki will display the text only in the **Question column**. For example, if the **Question column** text is "People in Ladakh speak", and the answer is "People in Ladakh speak Ladakhi", the **Answer column** will only display "Ladakhi", omitting the rest.
 
 ## Platform-Specific CSS
 
@@ -331,12 +331,12 @@ it to the media folder.
 After the font has been added to the media folder, you need to update the
 template.
 
-1. Click **Add** at the top of the main screen, and then select the
-   note type you want to change with the top left button.
+1. Click the **Add button** at the top of the **main screen**, and then select the
+   note type you want to change with the **top left button**.
 
-2. Click **Cards**.
+2. Click the **Cards button**.
 
-3. In the styling section, add the following text to the bottom (after
+3. In the **styling section**, add the following text to the bottom (after
    the last "}" character), replacing "\_arial.ttf" with the name of
    the file you copied into your media folder:
 
@@ -362,7 +362,7 @@ work.
 ## Night Mode
 
 You can customize the way templates appear when night mode is enabled in
-the preferences screen.
+the **preferences screen**.
 
 If you wanted a lighter grey background, you could use
 something like:

--- a/src/troubleshooting.md
+++ b/src/troubleshooting.md
@@ -23,7 +23,7 @@ If the problem goes away, that indicates an add-on is causing the problem.
 Remove any add-ons you don't need, and disable half of the others. If the
 problem continues, try the other half. Repeat the process until you've figured
 out which add-on is causing the problem. Then please report the issue to the
-add-on author, using the Copy Debug Info button, and pasting that into the
+add-on author, using the **Copy Debug Info button**, and pasting that into the
 report.
 
 ### 3. Check your Anki version
@@ -39,7 +39,7 @@ versions](platform/linux/distro-packages.md).
 
 ### 4. Check your database
 
-After restarting Anki, please try the **Tools → Check Database** menu item to
+After restarting Anki, please try the **Tools → Check Database menu item** to
 make sure your collection doesn't have any problems.
 
 ### 5. Restart your computer
@@ -54,7 +54,7 @@ restart Anki after each change.
 
 If you're using Anki version 23.10 or above, the easiest way is to open
 **Tools → Preferences** (or **Anki → Preferences** if you're on a Mac) and
-change the driver from the dropdown menu.
+change the driver from the **dropdown menu**.
 
 If you are on an older Anki version or if you cannot access the preferences for
 some reason, you can use the command-line instructions instead and manually
@@ -66,7 +66,7 @@ change the gldriver file:
 
 ### 7. Reset window sizes
 
-Sometimes pressing **reset window sizes** button in the preferences screen
+Sometimes pressing the **"reset window sizes" button** in the **preferences screen**
 immediately after starting Anki will help.
 
 ### 8. If the problem remains

--- a/src/troubleshooting.md
+++ b/src/troubleshooting.md
@@ -23,7 +23,7 @@ If the problem goes away, that indicates an add-on is causing the problem.
 Remove any add-ons you don't need, and disable half of the others. If the
 problem continues, try the other half. Repeat the process until you've figured
 out which add-on is causing the problem. Then please report the issue to the
-add-on author, using the **Copy Debug Info button**, and pasting that into the
+add-on author, using the **Copy Debug Info** button, and pasting that into the
 report.
 
 ### 3. Check your Anki version
@@ -39,7 +39,7 @@ versions](platform/linux/distro-packages.md).
 
 ### 4. Check your database
 
-After restarting Anki, please try the **Tools → Check Database menu item** to
+After restarting Anki, please try the **Tool > Check Database** menu item to
 make sure your collection doesn't have any problems.
 
 ### 5. Restart your computer
@@ -53,8 +53,8 @@ different video driver may help. Make sure you try all the driver options and
 restart Anki after each change.
 
 If you're using Anki version 23.10 or above, the easiest way is to open
-**Tools → Preferences** (or **Anki → Preferences** if you're on a Mac) and
-change the driver from the **dropdown menu**.
+**Tools > Preferences** (or **Anki > Preferences** if you're on a Mac) and
+change the driver from the dropdown menu.
 
 If you are on an older Anki version or if you cannot access the preferences for
 some reason, you can use the command-line instructions instead and manually
@@ -66,7 +66,7 @@ change the gldriver file:
 
 ### 7. Reset window sizes
 
-Sometimes pressing the **"reset window sizes" button** in the **preferences screen**
+Sometimes pressing the **reset window sizes** button in the **Preferences** screen
 immediately after starting Anki will help.
 
 ### 8. If the problem remains


### PR DESCRIPTION
This commit updates the documentation to consistently use bold formatting (e.g., **Button**) when referring to UI elements, as per the new style guidelines.

Manual and semi-automated checks were performed across all markdown files in the `src` directory to identify and correct instances where UI elements (buttons, menus, dialogs, windows, tabs, specific UI component names, etc.) were not bolded or were styled using backticks.

This change improves readability and adherence to the documentation style guide.