### PR TITLE
Fix: Standardize UI element bolding in additional documentation files

### DIFF
--- a/src/addons.md
+++ b/src/addons.md
@@ -4,12 +4,12 @@ Anki's capabilities can be extended with add-ons. Add-ons can provide
 features like extra support for specific languages, extra control over
 scheduling, and so on.
 
-To browse the list of available add-ons, select `Tools` → `Add-ons`, then click on `Get Add-ons`.
+To browse the list of available add-ons, select **Tools > Add-ons**, then click on **Get Add-ons**.
 Alternatively, open [ankiweb.net/shared/addons](https://ankiweb.net/shared/addons) in a web browser.
 
 If you have downloaded an add-on that is not working properly, or if you
 accidentally made a mistake when editing an add-on, you can use the
-"Delete" option in the menu to remove it.
+**Delete** option in the menu to remove it.
 
 Add-ons use and modify arbitrary parts of Anki’s codebase, so in some
 cases, updating Anki can break the compatibility with older add-ons. If
@@ -18,7 +18,7 @@ reporting the issue to the add-on author. If you rely on this add-on,
 you will need to keep using an older Anki version until the add-on gets
 an update.
 
-There is a "Contact Author" button on most add-ons pages on AnkiWeb,
+There is a **Contact Author** button on most add-ons pages on AnkiWeb,
 and many authors include their email address in the add-on, so if you
 need to get in touch with the author, editing the add-on and looking at
 the top of the file may help.

--- a/src/browsing.md
+++ b/src/browsing.md
@@ -87,7 +87,7 @@ to append the resulting search to the current search.
 
 If you regularly search for the same thing,
 you can save the current search by right-clicking the topmost item in the sidebar,
-choosing “Save Current Search” and typing in a name.
+choosing **Save Current Search** and typing in a name.
 You can also drag and drop any sidebar item onto this area to add an equivalent
 saved search, effectively pinning it at the top.
 

--- a/src/editing.md
+++ b/src/editing.md
@@ -33,7 +33,7 @@ them. Tags are separated by a space. If the tags area says
 …​then the note you add would have two tags.
 
 When you have entered text into the front and back, you can click the
-"Add" button or press <kbd>Ctrl</kbd>+<kbd>Enter</kbd> (<kbd>Command</kbd>+<kbd>Enter</kbd> on a Mac) to add the
+**Add** button or press <kbd>Ctrl</kbd>+<kbd>Enter</kbd> (<kbd>Command</kbd>+<kbd>Enter</kbd> on a Mac) to add the
 note to your collection. When you do so, a card will be created as well,
 and placed into the deck you chose. If you would like to edit a card you
 added, you can click the history button to search for a recently added
@@ -92,8 +92,8 @@ back, except by laboriously copying and pasting it for every note. By
 keeping content in separate fields, you make it much easier to adjust
 the layout of your cards in the future.
 
-To create a new type of note, choose Tools → Manage Note Types from the
-main Anki window. Then click "Add" to add a new type of note. You will now
+To create a new type of note, choose **Tools > Manage Note Types** from the
+main Anki window. Then click **Add** to add a new type of note. You will now
 see another screen that gives you a choice of note types to base the new
 type on. "Add" means to base the newly created type on one that comes
 with Anki. "Clone" means to base the newly created type on one that is
@@ -108,7 +108,7 @@ window, and you will return to the adding window.
 
 ## Customizing Fields
 
-To customize fields, click the "Fields…​" button when adding or editing
+To customize fields, click the **Fields...** button when adding or editing
 a note, or while the note type is selected in the Manage Note Types
 window.
 
@@ -443,8 +443,8 @@ of an image, testing your knowledge of that hidden information.
 
 To add IO cards to your collection, open the Add screen, click on "Type"
 and choose "Image Occlusion" from the list of built-in note types.
-Then, click on "Select Image" to load an image file saved on your
-computer's hard drive, or on "Paste image from clipboard"
+Then, click on **Select Image** to load an image file saved on your
+computer's hard drive, or on **Paste image from clipboard**
 if you have an image copied to the clipboard.
 
 ### Adding IO cards

--- a/src/getting-started.md
+++ b/src/getting-started.md
@@ -43,7 +43,7 @@ you're studying basic chemistry, you might see a question like:
     Q: Chemical symbol for oxygen?
 
 After deciding the answer is O, you click the
-"Show Answer" button, and Anki shows you:
+**Show Answer** button, and Anki shows you:
 
     Q: Chemical symbol for oxygen?
     A: O
@@ -154,7 +154,7 @@ they’d look like this:
 In Anki, this collection of related information is called a _note_ and each piece of information is contained in a _field_. In this example, the note
 has three fields: "French", "English", and "Page".
 
-To add and edit fields, click the "Fields…​" button while adding or
+To add and edit fields, click the **Fields...** button while adding or
 editing notes. For more information on fields, please see the
 [Customizing Fields](editing.md#customizing-fields) section.
 
@@ -197,7 +197,7 @@ ensure related cards don't appear too close to each other, and they
 allow you to fix a typing mistake or factual error once and have all the
 related cards update at once.
 
-To add and edit card types, click the "Cards…​" button while adding or
+To add and edit card types, click the **Cards...** button while adding or
 editing notes. For more information on card types, please see the [Cards and Templates](templates/intro.md) section.
 
 ### Note Types
@@ -244,8 +244,8 @@ types specifically for the content you are learning. The standard note types are
   such as anatomy and geography. For details, please see the [Image Occlusion](editing.md#image-occlusion)
   section of the manual.
 
-To add your own note types and modify existing ones, you can use Tools →
-Manage Note Types from the main Anki window.
+To add your own note types and modify existing ones, you can use **Tools > Manage Note Types**
+from the main Anki window.
 
 Notes and note types are common to your whole collection rather than
 limited to an individual deck. This means you can use different
@@ -267,13 +267,13 @@ You can watch a video about [Shared Decks and Review Basics](http://www.youtube.
 The easiest way to get started with Anki is to download a deck of cards
 someone else has shared:
 
-1. Click the "Get Shared" button at the bottom of the deck list.
+1. Click the **Get Shared** button at the bottom of the deck list.
 
-2. When you've found a deck you're interested in, click the "Download"
+2. When you've found a deck you're interested in, click the **Download**
    button to download a deck package.
 
 3. Double-click the downloaded package to import it into Anki, or go to
-   File → Import.
+   **File > Import**.
 
 Note: It’s not currently possible to add shared decks
 directly to your AnkiWeb account. You need to first import them to the

--- a/src/preferences.md
+++ b/src/preferences.md
@@ -2,8 +2,8 @@
 
 <!-- toc -->
 
-The preferences are available from the Tools menu on Windows/Linux, or
-the Anki menu on a Mac.
+The preferences are available from the **Tools** menu on Windows/Linux, or
+the **Anki** menu on a Mac.
 
 ## Appearance
 
@@ -109,10 +109,10 @@ unless the <kbd>Shift</kbd> key is held down. This option reverses the behaviour
 Controls how note types and decks interact. The default of "When adding, default
 to current deck" means that Anki saves the last-used note type for each deck and
 selects it again then next time you choose the deck (and, in addition, will
-start with the current deck selected when choosing Add from anywhere). The other
+start with the current deck selected when choosing **Add** from anywhere). The other
 option, "Change deck depending on note type," saves the last-used deck for each
 note type (and opens the add window to the last-used note type when you choose
-Add). This may be more convenient if you always use a single note type for each
+**Add**). This may be more convenient if you always use a single note type for each
 deck.
 
 The last used deck/note type is updated when you add a card. If you change the deck
@@ -149,7 +149,7 @@ with an older version that is on AnkiWeb.
 
 ### AnkiWeb Account
 
-When logged in, clicking on Log Out will log you out.
+When logged in, clicking on **Log Out** will log you out.
 
 ### Self-hosted Sync Server
 

--- a/src/preferences.md
+++ b/src/preferences.md
@@ -106,11 +106,11 @@ By default, formatting like bold and colors are kept when pasting,
 unless the <kbd>Shift</kbd> key is held down. This option reverses the behaviour.
 
 **Default deck**\
-Controls how note types and decks interact. The default of "When adding, default
-to current deck" means that Anki saves the last-used note type for each deck and
-selects it again then next time you choose the deck (and, in addition, will
+Controls how note types and decks interact. The default option **When adding, default
+to current deck** means that Anki saves the last-used note type for each deck and
+selects it again the next time you choose the deck (and, in addition, will
 start with the current deck selected when choosing **Add** from anywhere). The other
-option, "Change deck depending on note type," saves the last-used deck for each
+option, **Change deck depending on note type**, saves the last-used deck for each
 note type (and opens the add window to the last-used note type when you choose
 **Add**). This may be more convenient if you always use a single note type for each
 deck.


### PR DESCRIPTION
I've applied consistent bold formatting to UI element names as per the 2024 style guide to more files.

Changes include:
- Correctly bolding button and menu names (e.g., **Add** button, **Tools** menu).
- Ensuring only the UI element itself is bolded.
- Standardizing menu navigation to be bold and use '>' as a separator (e.g., **Tools > Add-ons**).

Files I modified in this pass:
- src/addons.md
- src/browsing.md
- src/editing.md
- src/getting-started.md
- src/preferences.md

No changes were needed in src/deck-options.md and src/studying.md from the initial check as the targeted elements already adhered to the guidelines.