### PR TITLE
Fix repeated words in docs

### DIFF
--- a/src/deck-options.md
+++ b/src/deck-options.md
@@ -584,7 +584,7 @@ interval would be around 13 days).
 An extra multiplier that is applied to all reviews. At its default of 1.00 it
 does nothing. If you set it to 0.80, intervals will be generated at
 80% of their normal size (so a 10 day interval would become 8 days).
-You can thus use the multiplier to to make your reviews less or more frequent.
+You can thus use the multiplier to make your reviews less or more frequent.
 
 For moderately difficult material, the average user should find they
 remember approximately 90% of mature cards when they come up for review. You

--- a/src/filtered-decks.md
+++ b/src/filtered-decks.md
@@ -165,7 +165,7 @@ overdue cards are, and how long their interval is. For example, a card with a
 current interval of 5 days that is overdue by 2 days, will display before a card
 with a current interval of 10 days that is overdue by 3 days.
 
-When using FSRS, overdueness is calculated based on on each card's retrievability,
+When using FSRS, overdueness is calculated based on each card's retrievability,
 and the desired retention in the deck preset.
 
 ## Steps & Returning


### PR DESCRIPTION
## Summary
- remove duplicated word in FSRS overdueness description
- fix repeated preposition in interval modifier explanation

## Testing
- not run (doc-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928a6649a34832d8f35bd2945401684)